### PR TITLE
Add the `AggregateMessageHandler` interface, and associated types.

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -44,8 +44,8 @@ type AggregateMessageHandler interface {
 	// manipulations must be applied by the instance's ApplyEvent() method,
 	// which is called for each recorded event message.
 	//
-	// If m was not expected by the handler as per the routes determined by calls
-	// to RouteCommand(), it must panic with an UnexpectedMessage error.
+	// If m was not expected by the handler it must panic with an UnexpectedMessage
+	// value.
 	HandleCommand(s AggregateScope, m Message)
 }
 

--- a/aggregate.go
+++ b/aggregate.go
@@ -1,0 +1,69 @@
+package dogma
+
+// AggregateMessageHandler is an interface for applying changes to an aggregate
+// via command messages.
+//
+// An aggregate is a collection of objects that represent some domain state
+// within the application.
+//
+// A request to change the state of an aggregate is represented by a command
+// message. The changes the command induces are represented by domain event
+// messages.
+//
+// Each command message is routed to a single aggregate instance, represented by
+// the AggregateRoot interface.
+type AggregateMessageHandler interface {
+	// New returns a new aggregate instance.
+	New() AggregateRoot
+
+	// RouteCommand determines how to route a command message to this handler,
+	// based on its type.
+	//
+	// If ok is true, m is routed to this handler, within the context of the
+	// aggregate instance nominated by id. id must not be empty.
+	//
+	// If p is true, a "routing probe" is being performed, in which case m is a
+	// zero-value and id is ignored. ok should be true if this handler should
+	// receive messages of m's type.
+	RouteCommand(m Message, p bool) (id string, ok bool)
+
+	// HandleCommand handles a command message within the scope of a specific
+	// aggregate instance.
+	//
+	// It inspects the state of the instance returned by s.Instance() to determine
+	// what state changes, if any, the command should produce.
+	//
+	// Any such change is indicated by calling s.RecordEvent() with an event
+	// message that represents that state change. The instance MUST NOT be modified
+	// directly by this method. Instead, the modifications must be made by the
+	// instance's ApplyEvent() method, which is called for each recorded event.
+	//
+	// If m is of an unsupported message type, it must panic with an
+	// UnexpectedMessage error.
+	HandleCommand(s AggregateScope, m Message)
+}
+
+// AggregateRoot is an interface to an aggregate instance.
+type AggregateRoot interface {
+	// ApplyEvent updates the aggregate instance to reflect the fact that a
+	// particular event has occurred.
+	ApplyEvent(m Message)
+}
+
+// AggregateScope is an interface used to access and manipulate an aggregate
+// when handling a command message.
+type AggregateScope interface {
+	// InstanceID is the ID the aggregate instance that the command message has
+	// been routed to.
+	InstanceID() string
+
+	// Instance loads and returns the aggregate instance that the command message
+	// has been routed to.
+	Instance() AggregateRoot
+
+	// RecordEvent records the occurrence of an event.
+	RecordEvent(m Message)
+
+	// Log logs an informational message within the context of this command.
+	Log(f string, v ...interface{})
+}

--- a/aggregate.go
+++ b/aggregate.go
@@ -53,7 +53,7 @@ type AggregateRoot interface {
 // AggregateScope is an interface used to access and manipulate an aggregate
 // when handling a command message.
 type AggregateScope interface {
-	// InstanceID is the ID the aggregate instance that the command message has
+	// InstanceID is the ID of the aggregate instance that the command message has
 	// been routed to.
 	InstanceID() string
 

--- a/aggregate.go
+++ b/aggregate.go
@@ -20,9 +20,9 @@ type AggregateMessageHandler interface {
 	// message should be routed to this handler.
 	//
 	// If p is false, then m is a command message that has been sent to the
-	// application. If m should be routed to this handler the implementation sets
-	// ok to true, and id to a non-empty value indicating the ID of the aggregate
-	// instance that the command targets.
+	// application. If m should be routed to this handler, the implementation sets
+	// ok to true and id to the ID of the aggregate instance that the command
+	// targets. id must not be empty if ok is true.
 	//
 	// If p is true, then the engine is performing a "routing probe". In this case
 	// m is a non-nil, zero-value message. The implementation sets ok to true if
@@ -44,12 +44,12 @@ type AggregateMessageHandler interface {
 	// manipulations must be applied by the instance's ApplyEvent() method,
 	// which is called for each recorded event message.
 	//
-	// If m was not expected by the handler, as per the routes determined by calls
+	// If m was not expected by the handler as per the routes determined by calls
 	// to RouteCommand(), it must panic with an UnexpectedMessage error.
 	HandleCommand(s AggregateScope, m Message)
 }
 
-// AggregateRoot is an interface implemented by the application, and used by
+// AggregateRoot is an interface implemented by the application and used by
 // the engine to apply changes to an aggregate.
 type AggregateRoot interface {
 	// ApplyEvent updates the aggregate instance to reflect the fact that a
@@ -57,7 +57,7 @@ type AggregateRoot interface {
 	ApplyEvent(m Message)
 }
 
-// AggregateScope is an interface implemented by the engine, and used by the
+// AggregateScope is an interface implemented by the engine and used by the
 // application to perform operations within the context of handling a command
 // message.
 type AggregateScope interface {

--- a/aggregate.go
+++ b/aggregate.go
@@ -1,69 +1,85 @@
 package dogma
 
-// AggregateMessageHandler is an interface for applying changes to an aggregate
-// via command messages.
+// AggregateMessageHandler is an interface implemented by the application and
+// used by the engine to cause changes to an aggregate via command messages.
 //
 // An aggregate is a collection of objects that represent some domain state
 // within the application.
 //
 // A request to change the state of an aggregate is represented by a command
-// message. The changes the command induces are represented by domain event
-// messages.
+// message. The changes caused by the command, if any, are represented by
+// domain event messages.
 //
-// Each command message is routed to a single aggregate instance, represented by
+// Each command message targets a single aggregate instance, represented by
 // the AggregateRoot interface.
 type AggregateMessageHandler interface {
 	// New returns a new aggregate instance.
 	New() AggregateRoot
 
-	// RouteCommand determines how to route a command message to this handler,
-	// based on its type.
+	// RouteCommand indicates whether a specific type or instance of a command
+	// message should be routed to this handler.
 	//
-	// If ok is true, m is routed to this handler, within the context of the
-	// aggregate instance nominated by id. id must not be empty.
+	// If p is false, then m is a command message that has been sent to the
+	// application. If m should be routed to this handler the implementation sets
+	// ok to true, and id to a non-empty value indicating the ID of the aggregate
+	// instance that the command targets.
 	//
-	// If p is true, a "routing probe" is being performed, in which case m is a
-	// zero-value and id is ignored. ok should be true if this handler should
-	// receive messages of m's type.
+	// If p is true, then the engine is performing a "routing probe". In this case
+	// m is a non-nil, zero-value message. The implementation sets ok to true if
+	// messages of this type should be routed to this message handler when they
+	// occur. The id output parameter is unused.
 	RouteCommand(m Message, p bool) (id string, ok bool)
 
-	// HandleCommand handles a command message within the scope of a specific
-	// aggregate instance.
+	// HandleCommand handles a command message that has been routed to this
+	// handler.
 	//
-	// It inspects the state of the instance returned by s.Instance() to determine
-	// what state changes, if any, the command should produce.
+	// Handling a command involves inspecting the state of the command's target
+	// aggregate instance to determine what changes, if any, should occur. Each
+	// change is indicated by recording an event message.
 	//
-	// Any such change is indicated by calling s.RecordEvent() with an event
-	// message that represents that state change. The instance MUST NOT be modified
-	// directly by this method. Instead, the modifications must be made by the
-	// instance's ApplyEvent() method, which is called for each recorded event.
+	// s provides access to the operations available within the scope of handling
+	// m, such as loading the targetted instance and recording event messages.
 	//
-	// If m is of an unsupported message type, it must panic with an
-	// UnexpectedMessage error.
+	// This method must not manipulate the targetted instance directly. Any such
+	// manipulations must be applied by the instance's ApplyEvent() method,
+	// which is called for each recorded event message.
+	//
+	// If m was not expected by the handler, as per the routes determined by calls
+	// to RouteCommand(), it must panic with an UnexpectedMessage error.
 	HandleCommand(s AggregateScope, m Message)
 }
 
-// AggregateRoot is an interface to an aggregate instance.
+// AggregateRoot is an interface implemented by the application, and used by
+// the engine to apply changes to an aggregate.
 type AggregateRoot interface {
 	// ApplyEvent updates the aggregate instance to reflect the fact that a
 	// particular event has occurred.
 	ApplyEvent(m Message)
 }
 
-// AggregateScope is an interface used to access and manipulate an aggregate
-// when handling a command message.
+// AggregateScope is an interface implemented by the engine, and used by the
+// application to perform operations within the context of handling a command
+// message.
 type AggregateScope interface {
-	// InstanceID is the ID of the aggregate instance that the command message has
-	// been routed to.
+	// InstanceID is the ID of the aggregate instance targetted by the command
+	// being handled.
 	InstanceID() string
 
-	// Instance loads and returns the aggregate instance that the command message
-	// has been routed to.
+	// Instance loads and returns the aggregate instance targetted by the command
+	// being handled.
 	Instance() AggregateRoot
 
-	// RecordEvent records the occurrence of an event.
+	// RecordEvent records the occurrence of an event as a result of the command
+	// being handled.
+	//
+	// The engine must call Instance().ApplyEvent(m) before returning, such that
+	// the applied changes are visible to the handler.
 	RecordEvent(m Message)
 
-	// Log logs an informational message within the context of this command.
+	// Log logs an informational message within the context of the command being
+	// handled.
+	//
+	// The log message should be worded such that it makes sense to anyone familiar
+	// with the business domain.
 	Log(f string, v ...interface{})
 }

--- a/message.go
+++ b/message.go
@@ -1,0 +1,5 @@
+package dogma
+
+// Message is an application-defined unit of data.
+type Message interface {
+}

--- a/message.go
+++ b/message.go
@@ -3,3 +3,9 @@ package dogma
 // Message is an application-defined unit of data.
 type Message interface {
 }
+
+// UnexpectedMessage is a panic value used by a message handler when it receives
+// a message that should not have been routed to it.
+var UnexpectedMessage unexpectedMessage
+
+type unexpectedMessage struct{}


### PR DESCRIPTION
I've brought the `Aggregate` interface over from the old repo, and made some terminology changes to bring the naming more into line with official DDD terminology.

The `Aggregate` interface is now named `AggregateMessageHandler`, to make it clear that the interface is to an object that handles messages, not "the aggregate" itself, which more correctly refers to a "collection of domain objects".

The `AggregateState` interface is now named `AggregateRoot`, to reflect that fact that it is just the interface to the root object within the aggregate.
