### PR TITLE
ADR-2: Document API Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog], and this project adheres to
+[Semantic Versioning].
+
+<!-- references -->
+[Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
+[Semantic Versioning]: https://semver.org/spec/v2.0.0.html
+
+## [Unreleased]
+
+### Added
+
+- Added the `Message` interface
+- Added the `UnexpectedMessage` panic value
+- Added interfaces for implementing domain aggregates
+
+<!-- references -->
+[Unreleased]: https://github.com/dogmatiq/dogma
+
+<!-- version template
+## [0.0.1] - YYYY-MM-DD
+
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+-->

--- a/docs/adr/0002-document-api-changes.md
+++ b/docs/adr/0002-document-api-changes.md
@@ -4,7 +4,7 @@ Date: 2018-12-07
 
 ## Status
 
-Proposed
+Approved
 
 ## Context
 
@@ -22,7 +22,11 @@ special attention drawn to changes that are not backwards compatible.
 
 ## Decision
 
-Undecided
+A changelog will be maintained as per [Keep a Changelog]. Unreleased changes
+should be added to the changelog as they are made.
+
+Git tags will be named according to the rules of [semantic versioning].
+Additionally, tag names are to be prefixed with a `v` as required by [Go modules].
 
 ## Consequences
 
@@ -34,3 +38,4 @@ version number.
 <!-- references -->
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
+[Go modules]: https://github.com/golang/go/wiki/Modules#modules

--- a/docs/adr/0002-document-api-changes.md
+++ b/docs/adr/0002-document-api-changes.md
@@ -1,0 +1,36 @@
+# 2. Document API Changes
+
+Date: 2018-12-07
+
+## Status
+
+Proposed
+
+## Context
+
+We need to advertise a meaningful history of changes to the Dogma API
+specification for both application developers and engine developers.
+
+The types of changes that have been made should be clearly identified, with
+special attention drawn to changes that are not backwards compatible.
+
+### Proposals
+
+- Maintain a `CHANGELOG.md` as per the recommendations of [Keep a Changelog]
+- Additionally, begin changelog entries that describe a BC break with `**[BC]**`
+- Periodically tag releases, using [semantic versioning]
+
+## Decision
+
+Undecided
+
+## Consequences
+
+Developers will have a single source of information about changes to the API.
+
+Compatibility between versions can be clearly determined by examining the
+version number.
+
+<!-- references -->
+[Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
+[semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,3 +11,4 @@ the ADR documents.
 ## Index
 
 * [1. Record architecture decisions](0001-record-architecture-decisions.md)
+* [2. Document API Changes](0002-document-api-changes.md)


### PR DESCRIPTION
This PR introduces ADR-2, which includes a proposal for how we document changes to the API over time.

Even though the ADR is only currently "proposed", I've included the `CHANGELOG.md` file as it would appear assuming the ADR is accepted.

This is mostly an academic endeavour to try out the process of building, proposing and approving an ADR, but it does also propose to do things a little differently than we have been in the past, in regards to the formatting of the changelog.

