### PR TITLE
ADR submission and approval process.

### DIFF
--- a/docs/adr/0004-adr-process.md
+++ b/docs/adr/0004-adr-process.md
@@ -1,0 +1,32 @@
+# 4. ADR Process
+
+Date: 2018-12-07
+
+## Status
+
+Approved
+
+## Context
+
+We need a documented process for proposing, discussing and ultimate accepting or
+rejecting ADRs via pull requests.
+
+## Decision
+
+We have decided to adopt a process that favours rapid changes, at least while
+the project is in its infancy. To this end, we will allow ADRs in the `proposed`
+status to be merged to `master` via PRs. The PRs may contain related code changes.
+
+Whenever a `proposed` ADR is merged to `master`, a GitHub issue is created to
+capture discussion about the ADR. Such issues are given the `adr` label.
+
+Any `proposed` ADRs remaining on `master` must be resolved either by approving
+the ADR, or by rejecting it and reverting any associated code changes.
+
+## Consequences
+
+This approach favours allows project maintaners to proceed with changes quickly,
+documenting their decisions, and giving us standard way to discuss those decisions.
+
+This comes at the cost of being potentially "expensive" at release time. We
+feel this is an compromise prior to the first major release.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,3 +13,4 @@ the ADR documents.
 * [1. Record architecture decisions](0001-record-architecture-decisions.md)
 * [2. Document API Changes](0002-document-api-changes.md)
 * [3. Aggregate Lifetime Control](0003-aggregate-lifetime-control.md)
+* [4. ADR Process](0004-adr-process.md)


### PR DESCRIPTION
We need to work out and document our process for submitting, evaluating, discussing and then approving or rejecting ADRs. Bearing in mind that ADRs are a record of decision making, meaning that we still want to keep rejected ADRs in the repo, especially if they provide enough useful information about why we chose NOT to do something.

This carries on from the conversation in #3.