### PR TITLE
Add create and destroy operations to AggregateScope.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
-### Added
-
-- Added the `Message` interface
-- Added the `UnexpectedMessage` panic value
-- Added interfaces for implementing domain aggregates
+- Initial release
 
 <!-- references -->
 [Unreleased]: https://github.com/dogmatiq/dogma

--- a/aggregate.go
+++ b/aggregate.go
@@ -76,11 +76,13 @@ type AggregateScope interface {
 	// It must be called before Root() or RecordEvent() can be called within this
 	// scope or the scope of any future command that targets the same instance.
 	//
-	// It may be called even if the targetted instance has already been created,
-	// in which case it is a no-op.
+	// It returns true if the targetted instance was created, or false if
+	// the instance already exists.
 	//
-	// RecordEvent() must be called at least once within the same scope.
-	Create()
+	// If it returns true, RecordEvent() must be called at least once within
+	// the same scope. This guarantees that the creation of every instance is
+	// represented by a domain event.
+	Create() bool
 
 	// Destroy destroys the targetted instance.
 	//
@@ -88,9 +90,14 @@ type AggregateScope interface {
 	// within this scope or the scope of any future command that targets the same
 	// instance, unless Create() is called again first.
 	//
-	// RecordEvent() must be called at least once within the same scope.
+	// It panics if the target instance does not currently exist.
 	//
-	// The precise semantics of destroy are implementation defined.
+	// RecordEvent() must be called at least once within the same scope. This
+	// guarantees that the destruction of every instance is represented by a domain
+	// event.
+	//
+	// The precise semantics of destroy are implementation defined. The aggregate
+	// data may be deleted or archived, for example.
 	Destroy()
 
 	// Root returns the root of the targetted aggregate instance.

--- a/aggregate.go
+++ b/aggregate.go
@@ -4,20 +4,19 @@ package dogma
 // used by the engine to cause changes to an aggregate via command messages.
 //
 // An aggregate is a collection of objects that represent some domain state
-// within the application.
+// within the application. All manipulation of the aggregate is performed via
+// one of its constituent object, known as the "root", and represented by the
+// AggregateRoot interface.
 //
 // A request to change the state of an aggregate is represented by a command
-// message. The changes caused by the command, if any, are represented by
-// domain event messages.
-//
-// Each command message targets a single aggregate instance, represented by
-// the AggregateRoot interface.
+// message. The changes caused by the command, if any, are represented by domain
+// event messages. Each command message targets a single aggregate instance.
 type AggregateMessageHandler interface {
-	// New returns a new aggregate instance.
+	// New constructs a new aggregate instance, and returns its root.
 	New() AggregateRoot
 
-	// RouteCommand indicates whether a specific type or instance of a command
-	// message should be routed to this handler.
+	// RouteCommand indicates whether a specific type or instance of a message
+	// should be routed to this handler as a command.
 	//
 	// If p is false, then m is a command message that has been sent to the
 	// application. If m should be routed to this handler, the implementation sets
@@ -26,8 +25,8 @@ type AggregateMessageHandler interface {
 	//
 	// If p is true, then the engine is performing a "routing probe". In this case
 	// m is a non-nil, zero-value message. The implementation sets ok to true if
-	// messages of this type should be routed to this message handler when they
-	// occur. The id output parameter is unused.
+	// messages of the same type as m should be routed to this message handler when
+	// they occur. The id output parameter is unused.
 	RouteCommand(m Message, p bool) (id string, ok bool)
 
 	// HandleCommand handles a command message that has been routed to this
@@ -38,19 +37,19 @@ type AggregateMessageHandler interface {
 	// change is indicated by recording an event message.
 	//
 	// s provides access to the operations available within the scope of handling
-	// m, such as loading the targetted instance and recording event messages.
+	// m, such as accessing the targetted instance and recording event messages.
 	//
-	// This method must not manipulate the targetted instance directly. Any such
-	// manipulations must be applied by the instance's ApplyEvent() method,
-	// which is called for each recorded event message.
+	// This method must not modify the targetted instance directly. All
+	// modifications must be applied by the instance's ApplyEvent() method, which
+	// is called for each recorded event message.
 	//
-	// If m was not expected by the handler it must panic with an UnexpectedMessage
-	// value.
+	// If m was not expected by the handler the implementation must panic with an
+	// UnexpectedMessage value.
 	HandleCommand(s AggregateScope, m Message)
 }
 
 // AggregateRoot is an interface implemented by the application and used by
-// the engine to apply changes to an aggregate.
+// the engine to apply changes to an aggregate instance.
 type AggregateRoot interface {
 	// ApplyEvent updates the aggregate instance to reflect the fact that a
 	// particular event has occurred.
@@ -60,14 +59,16 @@ type AggregateRoot interface {
 // AggregateScope is an interface implemented by the engine and used by the
 // application to perform operations within the context of handling a command
 // message.
+//
+// In the context of this interface, "the message" refers to the message being
+// handled, and "the instance" refers to the aggregate instance that is
+// targetted by that message.
 type AggregateScope interface {
-	// InstanceID is the ID of the aggregate instance targetted by the command
-	// being handled.
+	// InstanceID is the ID of the targetted aggregate instance.
 	InstanceID() string
 
-	// Instance loads and returns the aggregate instance targetted by the command
-	// being handled.
-	Instance() AggregateRoot
+	// Root returns the root of the targetted aggregate instance.
+	Root() AggregateRoot
 
 	// RecordEvent records the occurrence of an event as a result of the command
 	// being handled.

--- a/aggregate.go
+++ b/aggregate.go
@@ -109,7 +109,7 @@ type AggregateScope interface {
 	// the applied changes are visible to the handler.
 	RecordEvent(m Message)
 
-	// Log logs an informational message within the context of the command being
+	// Log records an informational message within the context of the command being
 	// handled.
 	//
 	// The log message should be worded such that it makes sense to anyone familiar

--- a/aggregate.go
+++ b/aggregate.go
@@ -8,9 +8,11 @@ package dogma
 // one of its constituent objects, known as the "root", and represented by the
 // AggregateRoot interface.
 //
-// A request to change the state of an aggregate is represented by a command
-// message. The changes caused by the command, if any, are represented by domain
-// event messages. Each command message targets a single aggregate instance.
+// A request to change the state of an aggregate instance is represented by a
+// command message. The changes caused by the command, if any, are represented
+// by domain event messages. Each command message targets a single aggregate
+// instance. A command can cause the creation or destruction of its target
+// instance.
 type AggregateMessageHandler interface {
 	// New constructs a new aggregate instance and returns its root.
 	New() AggregateRoot
@@ -21,7 +23,8 @@ type AggregateMessageHandler interface {
 	// If p is false, then m is a command message that has been sent to the
 	// application. If m should be routed to this handler, the implementation sets
 	// ok to true and id to the ID of the aggregate instance that the command
-	// targets. id must not be empty if ok is true.
+	// targets. The aggregate instance need not already exist in order for a
+	// command to target it. id must not be empty if ok is true.
 	//
 	// If p is true, then the engine is performing a "routing probe". In this case
 	// m is a non-nil, zero-value message. The implementation sets ok to true if
@@ -37,7 +40,8 @@ type AggregateMessageHandler interface {
 	// change is indicated by recording an event message.
 	//
 	// s provides access to the operations available within the scope of handling
-	// m, such as accessing the targetted instance and recording event messages.
+	// m, such as creating or destroying the targetted instance, accessing its
+	// state, and recording event messages.
 	//
 	// This method must not modify the targetted instance directly. All
 	// modifications must be applied by the instance's ApplyEvent() method, which

--- a/aggregate.go
+++ b/aggregate.go
@@ -5,7 +5,7 @@ package dogma
 //
 // An aggregate is a collection of objects that represent some domain state
 // within the application. All manipulation of the aggregate is performed via
-// one of its constituent object, known as the "root", and represented by the
+// one of its constituent objects, known as the "root", and represented by the
 // AggregateRoot interface.
 //
 // A request to change the state of an aggregate is represented by a command
@@ -72,7 +72,8 @@ type AggregateScope interface {
 	// It must be called before Root() or RecordEvent() can be called within this
 	// scope or the scope of any future command that targets the same instance.
 	//
-	// It may be called even if the targetted instance has already been created.
+	// It may be called even if the targetted instance has already been created,
+	// in which case it is a no-op.
 	//
 	// RecordEvent() must be called at least once within the same scope.
 	Create()
@@ -81,7 +82,7 @@ type AggregateScope interface {
 	//
 	// After it has been called neither Root() nor RecordEvent() can be called
 	// within this scope or the scope of any future command that targets the same
-	// instance.
+	// instance, unless Create() is called again first.
 	//
 	// RecordEvent() must be called at least once within the same scope.
 	//

--- a/docs/adr/0003-aggregate-lifetime-control.md
+++ b/docs/adr/0003-aggregate-lifetime-control.md
@@ -4,7 +4,7 @@ Date: 2018-12-10
 
 ## Status
 
-Proposed
+Approved
 
 ## Context
 
@@ -26,7 +26,7 @@ We've opted to name the methods used to create and destroy aggregate instances
 
 `Create()` is a fairly self explanatory name. This is an idempotent operation.
 The method returns `true` if the call actually resulted in the creation of the
-instance; or false if the instance already exists.
+instance; or `false` if the instance already exists.
 
 `Destroy()` was chosen in preference to words such as "delete", as depending on
 the engine implementation, no deletion necessarily occurs. It was chosen in

--- a/docs/adr/0003-aggregate-lifetime-control.md
+++ b/docs/adr/0003-aggregate-lifetime-control.md
@@ -1,0 +1,65 @@
+# 3. Aggregate Lifetime Control
+
+Date: 2018-12-10
+
+## Status
+
+Proposed
+
+## Context
+
+We need a way to control the lifetime of an aggregate from the domain layer.
+
+If you imagine an aggregate running atop a "CRUD-based" Dogma engine, it's easy
+to see that creation and destruction of aggregate data are necessary operations.
+This is less obvious in an event-sourced scenario where the notion of "deletion"
+is not present.
+
+We need to define these operations in such as a way that the domain implementor
+can use the operations in a meaningful way within their domain, but engine
+implementors are free to determine their own persistence semantics.
+
+## Decision
+
+We've opted to name the methods used to create and destroy aggregate instances
+`AggregateScope.Create()` and `Destroy()`, respectively.
+
+`Create()` is a fairly self explanatory name. This is an idempotent operation.
+The method returns `true` if the call actually resulted in the creation of the
+instance; or false if the instance already exists.
+
+`Destroy()` was chosen in preference to words such as "delete", as depending on
+the engine implementation, no deletion necessarily occurs. It was chosen in
+preference to "done", as it more clearly indicates that the aggregate instance
+state will be "reset". This could be implemented in an ES-based engine by
+recording internal events to represent the create/destroy operations, and only
+loading those events that occurred since the most recent creation.
+
+### Mandatory Events
+
+It was also decided to require an event message be recorded in the same scope
+as any successful call to `Create()` or `Destroy()`. This ensures that creation
+and deletion is always represented by a domain event.
+
+We decided against having `Create()` or `Destroy()` take an event as a
+parameter for two reasons:
+
+1. This would necessitate a further decision about `Create()` as to whether the
+event it is passed should be recorded in all cases or only if the instance
+does not already exist. Neither of which is appropriate in all cases.
+
+2. If we decide to relax this requirement in the future, those methods would
+have to lose those event arguments, breaking backwards compatibilty.
+
+## Consequences
+
+The appraoch taken tends towards reducing the chance of BC breaks by giving
+each method a single responsibility and placing the onus on the domain
+implementor to combine their use correctly.
+
+That said, the fact that `Create()` and `Destroy()` both mandate an event be
+recorded, but do not enforce this in any way may provide to be a point of
+confusion.
+
+More experience is needed implementing real applications in Dogma before we are
+willing to commit to adding event arguments to `Create()` and `Destroy()`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,3 +12,4 @@ the ADR documents.
 
 * [1. Record architecture decisions](0001-record-architecture-decisions.md)
 * [2. Document API Changes](0002-document-api-changes.md)
+* [3. Aggregate Lifetime Control](0003-aggregate-lifetime-control.md)


### PR DESCRIPTION
Fixes #5. 

This PR adds the `AggregateScope.Create()` and `Destroy()` methods.

I kept the original proposed names, as even though ES engines may not actually "delete" on `Destroy()`, they should still "reset" the aggregate state, such that it can be created again, just as they would for CRUD.

I felt it necessary to use more precise language regarding "instances" and "roots", specifically. To that end, I've renamed the `Instance()` method to `Root()`, and reworded some of the existing documentation in an attempt to improve clarity.

Edit: As I went to update the changelog I realised how nonsensical it was to list a whole bunch of "added" entries for the first release, so I updated it to simply read "initial release". 