### PR TITLE
Add `ProcessMessageHandler` and related interfaces.

### DIFF
--- a/docs/adr/0005-routing-of-commands-to-processes.md
+++ b/docs/adr/0005-routing-of-commands-to-processes.md
@@ -26,5 +26,5 @@ version than it is to remove it once it's in use.
 
 It's simpler to describe how the various message and handler types interact.
 
-As minor downside is that commands that unconditionally trigger a process still
+A minor downside is that commands that unconditionally trigger a process still
 have to pass through an aggregate that "does nothing".

--- a/docs/adr/0005-routing-of-commands-to-processes.md
+++ b/docs/adr/0005-routing-of-commands-to-processes.md
@@ -1,0 +1,30 @@
+# 5. Routing of commands to processes
+
+Date: 2018-12-11
+
+## Status
+
+Accepted
+
+## Context
+
+We need to decide whether command messages can be routed directly to processes.
+
+## Decision
+
+We have decided to disallow this behavior - processes may only handle events
+and timeout messages.
+
+If we were to allow processes to accept commands directly it may be tempting to
+implement domain idempotency in the process instead of in an aggregate where
+such logic belongs.
+
+Furthermore, it's easier to allow commands to be routed to processes in a future
+version than it is to remove it once it's in use.
+
+## Consequences
+
+It's simpler to describe how the various message and handler types interact.
+
+As minor downside is that commands that unconditionally trigger a process still
+have to pass through an aggregate that "does nothing".

--- a/docs/adr/0006-stateless-aggregates-and-processes.md
+++ b/docs/adr/0006-stateless-aggregates-and-processes.md
@@ -1,0 +1,44 @@
+# 6. Stateless aggregates and processes
+
+Date: 2018-12-11
+
+## Status
+
+Accepted
+
+## Context
+
+We need to decide how to represent aggregates and processes that do not have
+any state.
+
+This may sound nonsensical at first, but there are legitimate implementations of
+both that do not require any state, or perhaps more correctly the only state is
+whether or not they exist at all.
+
+This is perhaps more likely to occur in a CQRS/ES environment where the state
+associated with an aggregate is a "write-model". In this case, the only state
+that needs to be maintained is that which is required to make decisions about
+which events to produce.
+
+## Decision
+
+We've opted to have Dogma provide empty "root" implementations out of the box,
+for both aggregates and processes. The implementations should be unexported
+structs made available by exposed global variables in the `dogma` package.
+
+Handler implementations can return these values from their `New()` methods to
+indicate that they do not keep state.
+
+As these values are valid implementations of the `AggregateRoot` / `ProcessRoot`
+interfaces, engine implementations need not handle these impementations specially,
+though they can opt to do so by treating them as "sentinel" values.
+
+## Consequences
+
+By including these implementations we ensure that there is a standard,
+observable way to indicate statelessness without requiring vastly different
+codepaths.
+
+Stateless implementations still need to implement a `New()` method, which is
+perhaps overly verbose, but this could be mitigated by also providing embeddable
+structs with `New()` implementations that return the empty roots.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,3 +14,4 @@ the ADR documents.
 * [2. Document API Changes](0002-document-api-changes.md)
 * [3. Aggregate Lifetime Control](0003-aggregate-lifetime-control.md)
 * [4. ADR Process](0004-adr-process.md)
+* [5. Routing of commands to processes](0005-routing-of-commands-to-processes.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,3 +15,4 @@ the ADR documents.
 * [3. Aggregate Lifetime Control](0003-aggregate-lifetime-control.md)
 * [4. ADR Process](0004-adr-process.md)
 * [5. Routing of commands to processes](0005-routing-of-commands-to-processes.md)
+* [6. Stateless aggregates and processes](0006-stateless-aggregates-and-processes.md)

--- a/process.go
+++ b/process.go
@@ -1,0 +1,137 @@
+package dogma
+
+import "time"
+
+// ProcessMessageHandler is an interface implemented by the application and
+// used by the engine to model business processes.
+//
+// Many instances of each process type can be created. Each instance is a
+// collection of objects that represent the state of the process within the
+// application. All manipulation of a process instance is performed via one
+// of its constituent objects, known as the "root", and represented by the
+// ProcessRoot interface.
+//
+// Process instances are begun, updated and ended by domain event messages,
+// typically those recorded by an aggregate. The process can cause further
+// changes by executing new commands. Each event message can be routed to many
+// process types, but can target at most one instance of each type.
+type ProcessMessageHandler interface {
+	// New constructs a new process instance and returns its root.
+	New() ProcessRoot
+
+	// RouteEvent indicates whether a specific type or instance of a message
+	// should be routed to this handler as an event.
+	//
+	// If p is false, then m is an event message that has been made available to
+	// the application. If m should be routed to this handler, the implementation
+	// sets ok to true and id to the ID of the process instance that the event
+	// targets. The process instance need not already have begun in order for an
+	// event to target it. id must not be empty if ok is true.
+	//
+	// If p is true, then the engine is performing a "routing probe". In this case
+	// m is a non-nil, zero-value message. The implementation sets ok to true if
+	// messages of the same type as m should be routed to this message handler when
+	// they occur. The id output parameter is unused.
+	RouteEvent(m Message, p bool) (id string, ok bool)
+
+	// HandleEvent handles an event message that has been routed to this
+	// handler.
+	//
+	// Handling an event involves inspecting the state of the event's target
+	// process instance to determine what commands, if any, should be executed.
+	//
+	// s provides access to the operations available within the scope of handling
+	// m, such as beginning or ending the targetted instance, accessing its
+	// state, executing commands or scheduling timeouts.
+	//
+	// This method may manipulate the process's state directly.
+	//
+	// If m was not expected by the handler the implementation must panic with an
+	// UnexpectedMessage value.
+	HandleEvent(s ProcessScope, m Message)
+
+	// HandleTimeout handles a timeout message that has been scheduled with
+	// ProcessScope.ScheduleTimeout().
+	//
+	// Timeouts can be used to model time within the domain. For example, an
+	// application might use a timeout mark an invoice as overdue after some
+	// period of non-payment.
+	//
+	// Handling a timeout is much like handling an event in that the same
+	// operations are available to the handler via s.
+	//
+	// This method may manipulate the process's state directly.
+	//
+	// If m was not expected by the handler the implementation must panic with an
+	// UnexpectedMessage value.
+	HandleTimeout(s ProcessScope, m Message)
+}
+
+// ProcessRoot is an interface implemented by the application and used by
+// the engine to represent the state of a process instance.
+type ProcessRoot interface {
+}
+
+// ProcessScope is an interface implemented by the engine and used by the
+// application to perform operations within the context of handling an event or
+// timeout message.
+//
+// In the context of this interface, "the message" refers to the message being
+// handled and "the instance" refers to the process instance that is targetted
+// by that message. This message may either be an event, or a timeout message.
+type ProcessScope interface {
+	// InstanceID is the ID of the targetted process instance.
+	InstanceID() string
+
+	// Begin starts the targetted process instance.
+	//
+	// It must be called before Root(), ExecuteCommand() or ScheduleTimeout() can
+	// be called within this scope or the scope of any future event or timeout that
+	// targets the same instance.
+	//
+	// It returns true if the targetted instance was begun, or false if
+	// the instance had already begun.
+	Begin() bool
+
+	// End terminates the targetted process instance.
+	//
+	// After it has been called none of Root(), ExecuteCommand() or
+	// ScheduleTimeout() can be called within this scope or the scope of any future
+	// event or timeout that targets the same instance.
+	//
+	// It panics if the target instance does has not been begun.
+	//
+	// The precise semantics of ending a process instance are implementation
+	// defined. The engine is not required to allow re-beginning a process
+	// instance that has been ended.
+	End()
+
+	// Root returns the root of the targetted process instance.
+	//
+	// It panics if the instance has not been begun, or was begun but has
+	// subsequently been ended.
+	Root() ProcessRoot
+
+	// ExecuteCommand executes a command as a result of the event or timeout
+	// message being handled.
+	//
+	// It panics if the instance has not been begun, or was begun but has
+	// subsequently been ended.
+	ExecuteCommand(m Message)
+
+	// ScheduleTimeout schedules a timeout message to be returned to the process
+	// at a specific time.
+	//
+	// Any pending timeout messages are cancelled with the instance is ended.
+	//
+	// It panics if the instance has not been begun, or was begun but has
+	// subsequently been ended.
+	ScheduleTimeout(m Message, t time.Time)
+
+	// Log records an informational message within the context of the event or
+	// timeout being handled.
+	//
+	// The log message should be worded such that it makes sense to anyone familiar
+	// with the business domain.
+	Log(f string, v ...interface{})
+}

--- a/process.go
+++ b/process.go
@@ -1,6 +1,9 @@
 package dogma
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // ProcessMessageHandler is an interface implemented by the application and
 // used by the engine to model business processes.
@@ -32,7 +35,7 @@ type ProcessMessageHandler interface {
 	// m is a non-nil, zero-value message. The implementation sets ok to true if
 	// messages of the same type as m should be routed to this message handler when
 	// they occur. The id output parameter is unused.
-	RouteEvent(m Message, p bool) (id string, ok bool)
+	RouteEvent(ctx context.Context, m Message, p bool) (id string, ok bool, err error)
 
 	// HandleEvent handles an event message that has been routed to this
 	// handler.
@@ -48,7 +51,7 @@ type ProcessMessageHandler interface {
 	//
 	// If m was not expected by the handler the implementation must panic with an
 	// UnexpectedMessage value.
-	HandleEvent(s ProcessScope, m Message)
+	HandleEvent(ctx context.Context, s ProcessScope, m Message) error
 
 	// HandleTimeout handles a timeout message that has been scheduled with
 	// ProcessScope.ScheduleTimeout().
@@ -64,7 +67,7 @@ type ProcessMessageHandler interface {
 	//
 	// If m was not expected by the handler the implementation must panic with an
 	// UnexpectedMessage value.
-	HandleTimeout(s ProcessScope, m Message)
+	HandleTimeout(ctx context.Context, s ProcessScope, m Message) error
 }
 
 // ProcessRoot is an interface implemented by the application and used by

--- a/process.go
+++ b/process.go
@@ -57,7 +57,7 @@ type ProcessMessageHandler interface {
 	// ProcessScope.ScheduleTimeout().
 	//
 	// Timeouts can be used to model time within the domain. For example, an
-	// application might use a timeout mark an invoice as overdue after some
+	// application might use a timeout to mark an invoice as overdue after some
 	// period of non-payment.
 	//
 	// Handling a timeout is much like handling an event in that the same

--- a/process.go
+++ b/process.go
@@ -102,7 +102,7 @@ type ProcessScope interface {
 	// ScheduleTimeout() can be called within this scope or the scope of any future
 	// event or timeout that targets the same instance.
 	//
-	// It panics if the target instance does has not been begun.
+	// It panics if the target instance has not been begun.
 	//
 	// The precise semantics of ending a process instance are implementation
 	// defined. The engine is not required to allow re-beginning a process

--- a/process.go
+++ b/process.go
@@ -125,7 +125,7 @@ type ProcessScope interface {
 	// ScheduleTimeout schedules a timeout message to be returned to the process
 	// at a specific time.
 	//
-	// Any pending timeout messages are cancelled with the instance is ended.
+	// Any pending timeout messages are cancelled when the instance is ended.
 	//
 	// It panics if the instance has not been begun, or was begun but has
 	// subsequently been ended.


### PR DESCRIPTION
Here's a first-pass at #9. A few questions crop up immediately:

- [x] 1. Do we want to call the "process state" interface `ProcessRoot`.  I like the symmetry with aggregates, but this is not an established name within DDD. **Answer: Yes**
- [x] 2. Should commands be allowed to trigger processes? We had discussions in-person last week that led me to believe the answer is "no", but I've already forgotten why, so we need to discuss this again and document the decision in an ADR.  **Answer: No, for now**
- [x] 3. How do we represent stateless processes. Do we implement them as "generic message handlers", or do we, perhaps, explicitly document `nil` as a valid return value of `ProcessMessageHandler.New()`. **Answer: Via standard, empty implementations**