### PR TITLE
Domain message documentation.

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -1,7 +1,8 @@
 package dogma
 
 // AggregateMessageHandler is an interface implemented by the application and
-// used by the engine to cause changes to an aggregate via command messages.
+// used by the engine to cause changes to an aggregate via domain command
+// messages.
 //
 // Many instances of each aggregate type can be created. Each instance is a
 // collection of objects that represent some domain state within the
@@ -10,11 +11,12 @@ package dogma
 // AggregateRoot interface.
 //
 // A request to change the state of an aggregate instance is represented by a
-// command message. The changes caused by the command, if any, are represented
-// by domain event messages.
+// domain command message. The changes caused by the domain command message, if
+// any, are represented by domain event messages.
 //
-// Each command message targets a single aggregate instance of a specific type.
-// A command can cause the creation or destruction of its target instance.
+// Each domain command message targets a single aggregate instance of a specific
+// type. A domain command message can cause the creation or destruction of its
+// target instance.
 type AggregateMessageHandler interface {
 	// New constructs a new aggregate instance and returns its root.
 	New() AggregateRoot
@@ -22,34 +24,34 @@ type AggregateMessageHandler interface {
 	// Configure configures the behavior of the engine as it relates to this
 	// handler.
 	//
-	// c provides access to the various configuration options, such as
-	// specifying which command types are routed to this handler.
+	// c provides access to the various configuration options, such as specifying
+	// which types of domain command messages are routed to this handler.
 	Configure(c AggregateConfigurer)
 
 	// RouteCommandToInstance returns the ID of the aggregate instance that is
 	// targetted by m.
 	//
-	// It panics with the UnexpectedMessage value if m is not one of the command
-	// types that is routed to this handler via Configure().
+	// It panics with the UnexpectedMessage value if m is not one of the domain
+	// command types that is routed to this handler via Configure().
 	RouteCommandToInstance(m Message) string
 
-	// HandleCommand handles a command message that has been routed to this
+	// HandleCommand handles a domain command message that has been routed to this
 	// handler.
 	//
-	// Handling a command involves inspecting the state of the command's target
-	// aggregate instance to determine what changes, if any, should occur. Each
-	// change is indicated by recording an event message.
+	// Handling a domain command message involves inspecting the state of the
+	// target aggregate instance to determine what changes, if any, should occur.
+	// Each change is indicated by recording a domain event message.
 	//
 	// s provides access to the operations available within the scope of handling
 	// m, such as creating or destroying the targeted instance, accessing its
-	// state, and recording event messages.
+	// state, and recording domain event messages.
 	//
 	// This method must not modify the targeted instance directly. All
 	// modifications must be applied by the instance's ApplyEvent() method, which
-	// is called for each recorded event message.
+	// is called for each domain event message that is recorded via s.
 	//
-	// It panics with the UnexpectedMessage value if m is not one of the command
-	// types that is routed to this handler via Configure().
+	// It panics with the UnexpectedMessage value if m is not one of the domain
+	// command types that is routed to this handler via Configure().
 	HandleCommand(s AggregateScope, m Message)
 }
 
@@ -57,7 +59,7 @@ type AggregateMessageHandler interface {
 // the engine to apply changes to an aggregate instance.
 type AggregateRoot interface {
 	// ApplyEvent updates the aggregate instance to reflect the fact that a
-	// particular event has occurred.
+	// particular domain event has occurred.
 	ApplyEvent(m Message)
 }
 
@@ -70,18 +72,14 @@ type AggregateRoot interface {
 // In the context of this interface, "the handler" refers to the handler on
 // which Configure() has been called.
 type AggregateConfigurer interface {
-	// RouteCommandType configures the engine to route commands of the same type as m
-	// to the handler.
+	// RouteCommandType configures the engine to route domain command messages of
+	// the same type as m to the handler.
 	RouteCommandType(m Message)
 }
 
 // AggregateScope is an interface implemented by the engine and used by the
-// application to perform operations within the context of handling a command
-// message.
-//
-// In the context of this interface, "the message" refers to the message being
-// handled and "the instance" refers to the aggregate instance that is targeted
-// by that message.
+// application to perform operations within the context of handling a specific
+// domain command message.
 type AggregateScope interface {
 	// InstanceID is the ID of the targeted aggregate instance.
 	InstanceID() string
@@ -89,7 +87,8 @@ type AggregateScope interface {
 	// Create creates the targeted instance.
 	//
 	// It must be called before Root() or RecordEvent() can be called within this
-	// scope or the scope of any future command that targets the same instance.
+	// scope or the scope of any future domain command message that targets the
+	// same instance.
 	//
 	// It returns true if the targeted instance was created, or false if
 	// the instance already exists.
@@ -102,8 +101,8 @@ type AggregateScope interface {
 	// Destroy destroys the targeted instance.
 	//
 	// After it has been called neither Root() nor RecordEvent() can be called
-	// within this scope or the scope of any future command that targets the same
-	// instance, unless Create() is called again first.
+	// within this scope or the scope of any future domain command message that
+	// targets the same instance, unless Create() is called again first.
 	//
 	// It panics if the target instance does not currently exist.
 	//
@@ -121,8 +120,8 @@ type AggregateScope interface {
 	// subsequently been destroyed.
 	Root() AggregateRoot
 
-	// RecordEvent records the occurrence of an event as a result of the command
-	// being handled.
+	// RecordEvent records the occurrence of a domain event as a result of the
+	// domain command message that is being handled.
 	//
 	// It panics if the instance has not been created, or was created but has
 	// subsequently been destroyed.
@@ -131,8 +130,8 @@ type AggregateScope interface {
 	// the applied changes are visible to the handler.
 	RecordEvent(m Message)
 
-	// Log records an informational message within the context of the command being
-	// handled.
+	// Log records an informational message within the context of the domain
+	// command message that is being handled.
 	//
 	// The log message should be worded such that it makes sense to anyone familiar
 	// with the business domain.

--- a/message.go
+++ b/message.go
@@ -1,6 +1,16 @@
 package dogma
 
-// Message is an application-defined unit of data.
+// A Message is an application-defined unit of data.
+//
+// Messages are divided into two broad categories; "domain messages", which
+// relate to the application's domain logic, and "integration messages" which
+// are used to integrate the domain with "non-domain concerns", such as
+// third-party APIs.
+//
+// Within each category, messages are further divided into "commands" and
+// "events". Command messages represent a request to perform some action,
+// whereas event messages represent some occurrance which has already taken
+// place.
 type Message interface {
 }
 

--- a/message.go
+++ b/message.go
@@ -11,6 +11,10 @@ package dogma
 // "events". Command messages represent a request to perform some action,
 // whereas event messages represent some occurrance which has already taken
 // place.
+//
+// These message categorizations are largely conceptual. Within Dogma, they are
+// all modeled by the Message interface, though engine implementations may
+// require messages to implement more specific interfaces for each category.
 type Message interface {
 }
 

--- a/message.go
+++ b/message.go
@@ -2,19 +2,20 @@ package dogma
 
 // A Message is an application-defined unit of data.
 //
-// Messages are divided into two broad categories; "domain messages", which
+// Most messages fall into one of two broad categories; "domain messages", which
 // relate to the application's domain logic, and "integration messages" which
 // are used to integrate the domain with "non-domain concerns", such as
-// third-party APIs.
+// third-party APIs. There are other kinds of messages, such as process timeout
+// messages which do not clearly belong to one category or another.
 //
-// Within each category, messages are further divided into "commands" and
+// Within these categories, messages are further divided into "commands" and
 // "events". Command messages represent a request to perform some action,
 // whereas event messages represent some occurrance which has already taken
 // place.
 //
-// These message categorizations are largely conceptual. Within Dogma, they are
-// all modeled by the Message interface, though engine implementations may
-// require messages to implement more specific interfaces for each category.
+// These categorizations are largely conceptual. Within Dogma, they are all
+// modeled by the Message interface, though engine implementations may require
+// messages to implement more specific interfaces for each category.
 type Message interface {
 }
 

--- a/process.go
+++ b/process.go
@@ -20,7 +20,7 @@ import (
 // Each event message can be routed to many process types, but can target at
 // most one instance of each type.
 //
-// Processes are often use to integrate the domain layer with non-domain
+// Processes are often used to integrate the domain layer with non-domain
 // concerns, and as such they often accept and produce both domain messages and
 // integration messages.
 type ProcessMessageHandler interface {


### PR DESCRIPTION
This PR includes documentation changes begin to clarify the difference between "domain" messages and "integration" messages. 

I'll merge this, in the interest of moving on quickly, but if you guys don't mind reviewing it nonetheless, that would be great.  I *think* you've both seen most of the changes before.

After this, I'll proceed with changes as per the "message matrix" described in #35, to see how well that works.