### PR TITLE
Use more specific scope names in each handler.

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -52,7 +52,7 @@ type AggregateMessageHandler interface {
 	//
 	// It panics with the UnexpectedMessage value if m is not one of the domain
 	// command types that is routed to this handler via Configure().
-	HandleCommand(s AggregateScope, m Message)
+	HandleCommand(s AggregateCommandScope, m Message)
 }
 
 // AggregateRoot is an interface implemented by the application and used by
@@ -77,10 +77,10 @@ type AggregateConfigurer interface {
 	RouteCommandType(m Message)
 }
 
-// AggregateScope is an interface implemented by the engine and used by the
+// AggregateCommandScope is an interface implemented by the engine and used by the
 // application to perform operations within the context of handling a specific
 // domain command message.
-type AggregateScope interface {
+type AggregateCommandScope interface {
 	// InstanceID is the ID of the targeted aggregate instance.
 	InstanceID() string
 

--- a/docs/adr/0003-aggregate-lifetime-control.md
+++ b/docs/adr/0003-aggregate-lifetime-control.md
@@ -22,7 +22,8 @@ implementors are free to determine their own persistence semantics.
 ## Decision
 
 We've opted to name the methods used to create and destroy aggregate instances
-`AggregateCommandScope.Create()` and `Destroy()`, respectively.
+`AggregateScope.Create()` and `Destroy()`, respectively. Note that
+`AggregateScope` has since been renamed to `AggregateCommandScope`.
 
 `Create()` is a fairly self explanatory name. This is an idempotent operation.
 The method returns `true` if the call actually resulted in the creation of the

--- a/docs/adr/0003-aggregate-lifetime-control.md
+++ b/docs/adr/0003-aggregate-lifetime-control.md
@@ -22,7 +22,7 @@ implementors are free to determine their own persistence semantics.
 ## Decision
 
 We've opted to name the methods used to create and destroy aggregate instances
-`AggregateScope.Create()` and `Destroy()`, respectively.
+`AggregateCommandScope.Create()` and `Destroy()`, respectively.
 
 `Create()` is a fairly self explanatory name. This is an idempotent operation.
 The method returns `true` if the call actually resulted in the creation of the


### PR DESCRIPTION
This PR changes `AggregateScope` to `AggregateCommandScope` and splits `ProcessScope` into two interfaces: `ProcessEventScope` and `ProcessTimeoutScope`.

I decided to apply this change because firstly, the names are a little more meaningful. It also makes sense in the face of #35, which will introduce `CommandScope` and `EventScope` for non-domain handlers. Finally, the split between `ProcessEventScope` and `ProcessTimeoutScope` allows for some future proofing against BC breaks where these scopes may need different operations in the future. In fact, they are already different, because it's nonsensical to create a process instance from a timeout. By definition it must already exist to have created the timeout.