### PR TITLE
Add an `App` struct, used to define a Dogma application.

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -74,6 +74,10 @@ type AggregateRoot interface {
 // In the context of this interface, "the handler" refers to the handler on
 // which Configure() has been called.
 type AggregateConfigurer interface {
+	// Name sets the name of the handler. Each handler within an application must
+	// have a unique name.
+	Name(n string)
+
 	// RouteCommandType configures the engine to route domain command messages of
 	// the same type as m to the handler.
 	RouteCommandType(m Message)

--- a/app.go
+++ b/app.go
@@ -1,0 +1,25 @@
+package dogma
+
+// App is a definition of a Dogma application.
+type App struct {
+	// Name is a unique name for the application.
+	//
+	// The engine may make use of the application name for message routing.
+	Name string
+
+	// Aggregates is a collection of the aggregate message handlers that the
+	// application contains.
+	Aggregates []AggregateMessageHandler
+
+	// Aggregates is a collection of the process message handlers that the
+	// application contains.
+	Processes []ProcessMessageHandler
+
+	// Aggregates is a collection of the integration message handlers that the
+	// application contains.
+	Integrations []IntegrationMessageHandler
+
+	// Aggregates is a collection of the projection message handlers that the
+	// application contains.
+	Projections []ProjectionMessageHandler
+}

--- a/integration.go
+++ b/integration.go
@@ -32,6 +32,10 @@ type IntegrationMessageHandler interface {
 // In the context of this interface, "the handler" refers to the handler on
 // which Configure() has been called.
 type IntegrationConfigurer interface {
+	// Name sets the name of the handler. Each handler within an application must
+	// have a unique name.
+	Name(n string)
+
 	// RouteCommandType configures the engine to route integration command messages
 	// of the same type as m to the handler.
 	RouteCommandType(m Message)

--- a/process.go
+++ b/process.go
@@ -91,6 +91,10 @@ type ProcessRoot interface {
 // In the context of this interface, "the handler" refers to the handler on
 // which Configure() has been called.
 type ProcessConfigurer interface {
+	// Name sets the name of the handler. Each handler within an application must
+	// have a unique name.
+	Name(n string)
+
 	// RouteEventType configures the engine to route events of the same type as m
 	// to the handler.
 	RouteEventType(m Message)

--- a/projection.go
+++ b/projection.go
@@ -30,6 +30,10 @@ type ProjectionMessageHandler interface {
 // In the context of this interface, "the handler" refers to the handler on
 // which Configure() has been called.
 type ProjectionConfigurer interface {
+	// Name sets the name of the handler. Each handler within an application must
+	// have a unique name.
+	Name(n string)
+
 	// RouteEventType configures the engine to route events of the same type as m
 	// to the handler.
 	RouteEventType(m Message)


### PR DESCRIPTION
This replaces the "handler set" idea put forth in #11 - it is the single definition of an application that can potentially be executed by differing engines.

Note that this change adds a `Name()` method to the configurers, requiring each handler to define a unique name for itself. It's possible that some engines (such as the in-memory one) wont require the name, but it's useful even in logging if nothing else.