### PR TITLE
Rename the "embededable" types as "behaviors".

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -147,12 +147,15 @@ type DomainCommandExecutor interface {
 	ExecuteCommand(ctx context.Context, m Message) error
 }
 
-// StatelessAggregate is an embeddable type that provides an implementation of
-// AggregateMessageHandler.New() that always returns a StatelessAggregateRoot.
-type StatelessAggregate struct{}
+// StatelessAggregateBehavior can be embedded in AggregateMessageHandler
+// implementations to indicate that no state is kept between messages.
+//
+// It provides an implementation of AggregateMessageHandler.New() that always
+// returns a StatelessAggregateRoot.
+type StatelessAggregateBehavior struct{}
 
 // New returns StatelessAggregateRoot.
-func (StatelessAggregate) New() AggregateRoot {
+func (StatelessAggregateBehavior) New() AggregateRoot {
 	return StatelessAggregateRoot
 }
 
@@ -161,6 +164,12 @@ func (StatelessAggregate) New() AggregateRoot {
 // It can be returned by an AggregateMessageHandler.New() implementation to
 // indicate that no domain state is required beyond the existence/non-existence
 // of the aggregate instance.
+//
+// See also StatelessAggregateBehavior, which provides an implementation of
+// New() that returns this value.
+//
+// Engines may use this value as a sentinel, to provide an optimized code path
+// when no state is required.
 var StatelessAggregateRoot AggregateRoot = statelessAggregateRoot{}
 
 type statelessAggregateRoot struct{}

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/dogmatiq/dogma"
 )
 
-func TestStatelessAggregate_New_ReturnsStatelessAggregateRoot(t *testing.T) {
-	var v StatelessAggregate
+func TestStatelessAggregateBehavior_New_ReturnsStatelessAggregateRoot(t *testing.T) {
+	var v StatelessAggregateBehavior
 
 	r := v.New()
 

--- a/process.go
+++ b/process.go
@@ -203,12 +203,15 @@ type ProcessTimeoutScope interface {
 	Log(f string, v ...interface{})
 }
 
-// StatelessProcess is an embeddable type that provides an implementation of
-// ProcessMessageHandler.New() that always returns a StatelessProcessRoot.
-type StatelessProcess struct{}
+// StatelessProcessBehavior can be embedded in ProcessMessageHandler
+// implementations to indicate that no state is kept between messages.
+//
+// It provides an implementation of ProcessMessageHandler.New() that always
+// returns a StatelessProcessRoot.
+type StatelessProcessBehavior struct{}
 
 // New returns StatelessProcessRoot.
-func (StatelessProcess) New() ProcessRoot {
+func (StatelessProcessBehavior) New() ProcessRoot {
 	return StatelessProcessRoot
 }
 
@@ -217,6 +220,12 @@ func (StatelessProcess) New() ProcessRoot {
 // It can be returned by a ProcessMessageHandler.New() implementation to
 // indicate that no domain state is required beyond the existence/non-existence
 // of the process instance.
+//
+// See also StatelessProcessBehavior, which provides an implementation of
+// New() that returns this value.
+//
+// Engines may use this value as a sentinel, to provide an optimized code path
+// when no state is required.
 var StatelessProcessRoot ProcessRoot = statelessProcessRoot{}
 
 type statelessProcessRoot struct{}

--- a/process.go
+++ b/process.go
@@ -230,11 +230,14 @@ var StatelessProcessRoot ProcessRoot = statelessProcessRoot{}
 
 type statelessProcessRoot struct{}
 
-// NoTimeouts is an embeddable type that provides an implementation of
-// Process.HandleTimeout() that always panics with the UnexpectedMessage value.
-type NoTimeouts struct{}
+// NoTimeoutBehavior can be embedded in ProcessMessageHandler implementations to
+// indicate that no timeout messages are used.
+//
+// It provides an implementation of ProcessMessageHandler.HandleTimeout() that always
+// panics with the UnexpectedMessage value.
+type NoTimeoutBehavior struct{}
 
 // HandleTimeout panic with the UnexpectedMessage value.
-func (NoTimeouts) HandleTimeout(context.Context, ProcessTimeoutScope, Message) error {
+func (NoTimeoutBehavior) HandleTimeout(context.Context, ProcessTimeoutScope, Message) error {
 	panic(UnexpectedMessage)
 }

--- a/process_test.go
+++ b/process_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/dogmatiq/dogma"
 )
 
-func TestStatelessProcess_New_ReturnsStatelessProcessRoot(t *testing.T) {
-	var v StatelessProcess
+func TestStatelessProcessBehavior_New_ReturnsStatelessProcessRoot(t *testing.T) {
+	var v StatelessProcessBehavior
 
 	r := v.New()
 

--- a/process_test.go
+++ b/process_test.go
@@ -17,8 +17,8 @@ func TestStatelessProcessBehavior_New_ReturnsStatelessProcessRoot(t *testing.T) 
 	}
 }
 
-func TestNoTimeouts_HandleTimeout_Panics(t *testing.T) {
-	var v NoTimeouts
+func TestNoTimeoutBehavior_HandleTimeout_Panics(t *testing.T) {
+	var v NoTimeoutBehavior
 	ctx := context.Background()
 
 	defer func() {


### PR DESCRIPTION
As discussed in #43 - I like that these are bit more explicit as to purpose.