### PR TITLE
Add `IsEqual()` to `AggregateRoot` and `ProcessRoot`.

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -63,6 +63,9 @@ type AggregateRoot interface {
 	// ApplyEvent updates the aggregate instance to reflect the fact that a
 	// particular domain event has occurred.
 	ApplyEvent(m Message)
+
+	// IsEqual returns true if this aggregate root is equal to r.
+	IsEqual(r AggregateRoot) bool
 }
 
 // AggregateConfigurer is an interface implemented by the engine and used by
@@ -182,4 +185,12 @@ func (statelessAggregateRoot) ApplyEvent(m Message) {
 	if m == nil {
 		panic("event must not be nil")
 	}
+}
+
+func (statelessAggregateRoot) IsEqual(r AggregateRoot) bool {
+	if r == nil {
+		panic("aggregate root must not be nil")
+	}
+
+	return r == StatelessAggregateRoot
 }

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -6,6 +6,16 @@ import (
 	. "github.com/dogmatiq/dogma"
 )
 
+type testAggregateRoot struct{}
+
+func (testAggregateRoot) ApplyEvent(m Message) {
+	panic("not implemented")
+}
+
+func (testAggregateRoot) IsEqual(r AggregateRoot) bool {
+	panic("not implemented")
+}
+
 func TestStatelessAggregateBehavior_New_ReturnsStatelessAggregateRoot(t *testing.T) {
 	var v StatelessAggregateBehavior
 
@@ -35,4 +45,30 @@ func TestStatelessAggregateRoot_ApplyEvent_PanicsOnNil(t *testing.T) {
 	}()
 
 	StatelessAggregateRoot.ApplyEvent(nil)
+}
+
+func TestStatelessAggregateRoot_IsEqual(t *testing.T) {
+	if !StatelessAggregateRoot.IsEqual(StatelessAggregateRoot) {
+		t.Fatal("StatelessAggregateRoot is not equal to itself")
+	}
+
+	if StatelessAggregateRoot.IsEqual(testAggregateRoot{}) {
+		t.Fatal("StatelessAggregateRoot is equal to a different aggregate root")
+	}
+}
+
+func TestStatelessAggregateRoot_IsEqual_PanicsOnNil(t *testing.T) {
+	defer func() {
+		r := recover()
+
+		if r == nil {
+			t.Fatal("did not panic")
+		}
+
+		if r != "aggregate root must not be nil" {
+			t.Fatal("did not panic with expected message")
+		}
+	}()
+
+	StatelessAggregateRoot.IsEqual(nil)
 }

--- a/process.go
+++ b/process.go
@@ -80,6 +80,8 @@ type ProcessMessageHandler interface {
 // ProcessRoot is an interface implemented by the application and used by
 // the engine to represent the state of a process instance.
 type ProcessRoot interface {
+	// IsEqual returns true if this process root is equal to r.
+	IsEqual(r ProcessRoot) bool
 }
 
 // ProcessConfigurer is an interface implemented by the engine and used by
@@ -233,6 +235,14 @@ func (StatelessProcessBehavior) New() ProcessRoot {
 var StatelessProcessRoot ProcessRoot = statelessProcessRoot{}
 
 type statelessProcessRoot struct{}
+
+func (statelessProcessRoot) IsEqual(r ProcessRoot) bool {
+	if r == nil {
+		panic("process root must not be nil")
+	}
+
+	return r == StatelessProcessRoot
+}
 
 // NoTimeoutBehavior can be embedded in ProcessMessageHandler implementations to
 // indicate that no timeout messages are used.

--- a/process_test.go
+++ b/process_test.go
@@ -7,6 +7,16 @@ import (
 	. "github.com/dogmatiq/dogma"
 )
 
+type testProcessRoot struct{}
+
+func (testProcessRoot) ApplyEvent(m Message) {
+	panic("not implemented")
+}
+
+func (testProcessRoot) IsEqual(r ProcessRoot) bool {
+	panic("not implemented")
+}
+
 func TestStatelessProcessBehavior_New_ReturnsStatelessProcessRoot(t *testing.T) {
 	var v StatelessProcessBehavior
 
@@ -15,6 +25,32 @@ func TestStatelessProcessBehavior_New_ReturnsStatelessProcessRoot(t *testing.T) 
 	if r != StatelessProcessRoot {
 		t.Fatal("unexpected value returned")
 	}
+}
+
+func TestStatelessProcessRoot_IsEqual(t *testing.T) {
+	if !StatelessProcessRoot.IsEqual(StatelessProcessRoot) {
+		t.Fatal("StatelessProcessRoot is not equal to itself")
+	}
+
+	if StatelessProcessRoot.IsEqual(testProcessRoot{}) {
+		t.Fatal("StatelessProcessRoot is equal to a different process root")
+	}
+}
+
+func TestStatelessProcessRoot_IsEqual_PanicsOnNil(t *testing.T) {
+	defer func() {
+		r := recover()
+
+		if r == nil {
+			t.Fatal("did not panic")
+		}
+
+		if r != "process root must not be nil" {
+			t.Fatal("did not panic with expected message")
+		}
+	}()
+
+	StatelessProcessRoot.IsEqual(nil)
 }
 
 func TestNoTimeoutBehavior_HandleTimeout_Panics(t *testing.T) {


### PR DESCRIPTION
Partially addresses #11.
