### PR TITLE
Add `IsEqual()` and `Clone()` methods to aggregate/process roots.

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -66,6 +66,9 @@ type AggregateRoot interface {
 
 	// IsEqual returns true if this aggregate root is equal to r.
 	IsEqual(r AggregateRoot) bool
+
+	// Clone returns a deep-copy of this aggregate root.
+	Clone() AggregateRoot
 }
 
 // AggregateConfigurer is an interface implemented by the engine and used by
@@ -193,4 +196,8 @@ func (statelessAggregateRoot) IsEqual(r AggregateRoot) bool {
 	}
 
 	return r == StatelessAggregateRoot
+}
+
+func (statelessAggregateRoot) Clone() AggregateRoot {
+	return StatelessAggregateRoot
 }

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -16,6 +16,10 @@ func (testAggregateRoot) IsEqual(r AggregateRoot) bool {
 	panic("not implemented")
 }
 
+func (testAggregateRoot) Clone() AggregateRoot {
+	panic("not implemented")
+}
+
 func TestStatelessAggregateBehavior_New_ReturnsStatelessAggregateRoot(t *testing.T) {
 	var v StatelessAggregateBehavior
 
@@ -71,4 +75,10 @@ func TestStatelessAggregateRoot_IsEqual_PanicsOnNil(t *testing.T) {
 	}()
 
 	StatelessAggregateRoot.IsEqual(nil)
+}
+
+func TestStatelessAggregateRoot_Clone(t *testing.T) {
+	if !StatelessAggregateRoot.Clone().IsEqual(StatelessAggregateRoot) {
+		t.Fatal("clone is not StatelessAggregateRoot")
+	}
 }

--- a/process.go
+++ b/process.go
@@ -82,6 +82,9 @@ type ProcessMessageHandler interface {
 type ProcessRoot interface {
 	// IsEqual returns true if this process root is equal to r.
 	IsEqual(r ProcessRoot) bool
+
+	// Clone returns a deep-copy of this process root.
+	Clone() ProcessRoot
 }
 
 // ProcessConfigurer is an interface implemented by the engine and used by
@@ -242,6 +245,10 @@ func (statelessProcessRoot) IsEqual(r ProcessRoot) bool {
 	}
 
 	return r == StatelessProcessRoot
+}
+
+func (statelessProcessRoot) Clone() ProcessRoot {
+	return StatelessProcessRoot
 }
 
 // NoTimeoutBehavior can be embedded in ProcessMessageHandler implementations to

--- a/process_test.go
+++ b/process_test.go
@@ -17,6 +17,10 @@ func (testProcessRoot) IsEqual(r ProcessRoot) bool {
 	panic("not implemented")
 }
 
+func (testProcessRoot) Clone() ProcessRoot {
+	panic("not implemented")
+}
+
 func TestStatelessProcessBehavior_New_ReturnsStatelessProcessRoot(t *testing.T) {
 	var v StatelessProcessBehavior
 
@@ -66,4 +70,10 @@ func TestNoTimeoutBehavior_HandleTimeout_Panics(t *testing.T) {
 	}()
 
 	v.HandleTimeout(ctx, nil, nil)
+}
+
+func TestStatelessProcessRoot_Clone(t *testing.T) {
+	if !StatelessProcessRoot.Clone().IsEqual(StatelessProcessRoot) {
+		t.Fatal("clone is not StatelessProcessRoot")
+	}
 }


### PR DESCRIPTION
Partially addresses #11.