### PR TITLE
Revert "Merge pull request #50 from dogmatiq/11-compare-and-clone"

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -63,12 +63,6 @@ type AggregateRoot interface {
 	// ApplyEvent updates the aggregate instance to reflect the fact that a
 	// particular domain event has occurred.
 	ApplyEvent(m Message)
-
-	// IsEqual returns true if this aggregate root is equal to r.
-	IsEqual(r AggregateRoot) bool
-
-	// Clone returns a deep-copy of this aggregate root.
-	Clone() AggregateRoot
 }
 
 // AggregateConfigurer is an interface implemented by the engine and used by
@@ -188,16 +182,4 @@ func (statelessAggregateRoot) ApplyEvent(m Message) {
 	if m == nil {
 		panic("event must not be nil")
 	}
-}
-
-func (statelessAggregateRoot) IsEqual(r AggregateRoot) bool {
-	if r == nil {
-		panic("aggregate root must not be nil")
-	}
-
-	return r == StatelessAggregateRoot
-}
-
-func (statelessAggregateRoot) Clone() AggregateRoot {
-	return StatelessAggregateRoot
 }

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -6,20 +6,6 @@ import (
 	. "github.com/dogmatiq/dogma"
 )
 
-type testAggregateRoot struct{}
-
-func (testAggregateRoot) ApplyEvent(m Message) {
-	panic("not implemented")
-}
-
-func (testAggregateRoot) IsEqual(r AggregateRoot) bool {
-	panic("not implemented")
-}
-
-func (testAggregateRoot) Clone() AggregateRoot {
-	panic("not implemented")
-}
-
 func TestStatelessAggregateBehavior_New_ReturnsStatelessAggregateRoot(t *testing.T) {
 	var v StatelessAggregateBehavior
 
@@ -49,36 +35,4 @@ func TestStatelessAggregateRoot_ApplyEvent_PanicsOnNil(t *testing.T) {
 	}()
 
 	StatelessAggregateRoot.ApplyEvent(nil)
-}
-
-func TestStatelessAggregateRoot_IsEqual(t *testing.T) {
-	if !StatelessAggregateRoot.IsEqual(StatelessAggregateRoot) {
-		t.Fatal("StatelessAggregateRoot is not equal to itself")
-	}
-
-	if StatelessAggregateRoot.IsEqual(testAggregateRoot{}) {
-		t.Fatal("StatelessAggregateRoot is equal to a different aggregate root")
-	}
-}
-
-func TestStatelessAggregateRoot_IsEqual_PanicsOnNil(t *testing.T) {
-	defer func() {
-		r := recover()
-
-		if r == nil {
-			t.Fatal("did not panic")
-		}
-
-		if r != "aggregate root must not be nil" {
-			t.Fatal("did not panic with expected message")
-		}
-	}()
-
-	StatelessAggregateRoot.IsEqual(nil)
-}
-
-func TestStatelessAggregateRoot_Clone(t *testing.T) {
-	if !StatelessAggregateRoot.Clone().IsEqual(StatelessAggregateRoot) {
-		t.Fatal("clone is not StatelessAggregateRoot")
-	}
 }

--- a/process.go
+++ b/process.go
@@ -80,11 +80,6 @@ type ProcessMessageHandler interface {
 // ProcessRoot is an interface implemented by the application and used by
 // the engine to represent the state of a process instance.
 type ProcessRoot interface {
-	// IsEqual returns true if this process root is equal to r.
-	IsEqual(r ProcessRoot) bool
-
-	// Clone returns a deep-copy of this process root.
-	Clone() ProcessRoot
 }
 
 // ProcessConfigurer is an interface implemented by the engine and used by
@@ -238,18 +233,6 @@ func (StatelessProcessBehavior) New() ProcessRoot {
 var StatelessProcessRoot ProcessRoot = statelessProcessRoot{}
 
 type statelessProcessRoot struct{}
-
-func (statelessProcessRoot) IsEqual(r ProcessRoot) bool {
-	if r == nil {
-		panic("process root must not be nil")
-	}
-
-	return r == StatelessProcessRoot
-}
-
-func (statelessProcessRoot) Clone() ProcessRoot {
-	return StatelessProcessRoot
-}
 
 // NoTimeoutBehavior can be embedded in ProcessMessageHandler implementations to
 // indicate that no timeout messages are used.

--- a/process_test.go
+++ b/process_test.go
@@ -7,20 +7,6 @@ import (
 	. "github.com/dogmatiq/dogma"
 )
 
-type testProcessRoot struct{}
-
-func (testProcessRoot) ApplyEvent(m Message) {
-	panic("not implemented")
-}
-
-func (testProcessRoot) IsEqual(r ProcessRoot) bool {
-	panic("not implemented")
-}
-
-func (testProcessRoot) Clone() ProcessRoot {
-	panic("not implemented")
-}
-
 func TestStatelessProcessBehavior_New_ReturnsStatelessProcessRoot(t *testing.T) {
 	var v StatelessProcessBehavior
 
@@ -29,32 +15,6 @@ func TestStatelessProcessBehavior_New_ReturnsStatelessProcessRoot(t *testing.T) 
 	if r != StatelessProcessRoot {
 		t.Fatal("unexpected value returned")
 	}
-}
-
-func TestStatelessProcessRoot_IsEqual(t *testing.T) {
-	if !StatelessProcessRoot.IsEqual(StatelessProcessRoot) {
-		t.Fatal("StatelessProcessRoot is not equal to itself")
-	}
-
-	if StatelessProcessRoot.IsEqual(testProcessRoot{}) {
-		t.Fatal("StatelessProcessRoot is equal to a different process root")
-	}
-}
-
-func TestStatelessProcessRoot_IsEqual_PanicsOnNil(t *testing.T) {
-	defer func() {
-		r := recover()
-
-		if r == nil {
-			t.Fatal("did not panic")
-		}
-
-		if r != "process root must not be nil" {
-			t.Fatal("did not panic with expected message")
-		}
-	}()
-
-	StatelessProcessRoot.IsEqual(nil)
 }
 
 func TestNoTimeoutBehavior_HandleTimeout_Panics(t *testing.T) {
@@ -70,10 +30,4 @@ func TestNoTimeoutBehavior_HandleTimeout_Panics(t *testing.T) {
 	}()
 
 	v.HandleTimeout(ctx, nil, nil)
-}
-
-func TestStatelessProcessRoot_Clone(t *testing.T) {
-	if !StatelessProcessRoot.Clone().IsEqual(StatelessProcessRoot) {
-		t.Fatal("clone is not StatelessProcessRoot")
-	}
 }


### PR DESCRIPTION
This PR reverts the addition of the `IsEqual()` and `Clone()` methods to the `AggregateRoot` and `ProcessRoot` interfaces.

Fixes #11
