### PR TITLE
Rename the "external" interfaces.

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -1,7 +1,5 @@
 package dogma
 
-import "context"
-
 // AggregateMessageHandler is an interface implemented by the application and
 // used by the engine to cause changes to an aggregate via domain command
 // messages.
@@ -142,13 +140,6 @@ type AggregateCommandScope interface {
 	// The log message should be worded such that it makes sense to anyone familiar
 	// with the business domain.
 	Log(f string, v ...interface{})
-}
-
-// DomainCommandExecutor is an interface implemented by the engine and used by
-// the application to execute domain commands from outside the Dogma engine.
-type DomainCommandExecutor interface {
-	// ExecuteCommand executes a command that does not have a causal message.
-	ExecuteCommand(ctx context.Context, m Message) error
 }
 
 // StatelessAggregateBehavior can be embedded in AggregateMessageHandler

--- a/doc.go
+++ b/doc.go
@@ -1,2 +1,16 @@
-// Package dogma is an API specification for message-based applications.
+// Package dogma is an specification and API for message-based applications.
+//
+// It attempts to define a practical standard for authoring message-based
+// applications in a manner agnostic to the mechanisms by which messages are
+// transported and application state is persisted.
+//
+// To that end, this package defines a set of interfaces and recommendations for
+// both "application developers" - those who are authoring a message-based
+// application, and for "engine developers" - those who are authoring the
+// platform responsible for message transport and persistence.
+//
+// The API documentation takes the form of a specification, and as such the key
+// words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD
+// NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+// interpreted as described in RFC 2119.
 package dogma

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-// Package dogma is an specification and API for message-based applications.
+// Package dogma is a specification and API for message-based applications.
 //
 // It attempts to define a practical standard for authoring message-based
 // applications in a manner agnostic to the mechanisms by which messages are

--- a/external.go
+++ b/external.go
@@ -1,0 +1,49 @@
+package dogma
+
+import "context"
+
+// CommandExecutor is an interface implemented by the engine and used by the
+// application to execute commands outside of a Dogma message handler.
+//
+// It is RECOMMENDED that engines provide an implementation of this interface.
+type CommandExecutor interface {
+	// ExecuteCommand enqueues a command for execution.
+	//
+	// If nil is returned, the engine MUST provide reasonable guarantees that the
+	// message will be dispatched to the appropriate handler. For example, the
+	// engine is responsible for retrying the message in the face of a transient
+	// error.
+	//
+	// If an error is returned, the command may not have been enqueued. The
+	// application SHOULD retry executing the command.
+	//
+	// The engine MAY handle the message synchronously, however the application
+	// SHOULD NOT assume that the message has been handled immediately.
+	//
+	// If ctx has a deadline, it MUST NOT be used by the engine as a mechanism for
+	// message expiration.
+	ExecuteCommand(ctx context.Context, m Message) error
+}
+
+// EventRecorder is an interface implemented by the engine and used by the
+// application to record events outside of a Dogma message handler.
+//
+// It is RECOMMENDED that engines provide an implementation of this interface.
+type EventRecorder interface {
+	// RecordEvent records the occurrence of an event.
+	//
+	// If nil is returned, the engine MUST provide reasonable guarantees that the
+	// message will be dispatched to the appropriate handler. For example, the
+	// engine is responsible for retrying the message in the face of a transient
+	// error.
+	//
+	// If an error is returned, the event may not have been recorded. The
+	// application SHOULD retry recording the event.
+	//
+	// The engine MAY handle the message synchronously, however the application
+	// SHOULD NOT assume that the message has been handled immediately.
+	//
+	// If ctx has a deadline, it MUST NOT be used by the engine as a mechanism for
+	// message expiration.
+	RecordEvent(ctx context.Context, m Message) error
+}

--- a/integration.go
+++ b/integration.go
@@ -53,12 +53,3 @@ type IntegrationCommandScope interface {
 	// command message that is being handled.
 	Log(f string, v ...interface{})
 }
-
-// IntegrationEventRecorder is an interface implemented by the engine and used
-// by the appliation to record integration events that occur outside an
-// integration message handler.
-type IntegrationEventRecorder interface {
-	// RecordEvent records the occurrence of an integration event that does not
-	// have a causal message.
-	RecordEvent(ctx context.Context, m Message) error
-}


### PR DESCRIPTION
- `DomainCommandExecutor` becomes `CommandExecutor`
- `IntegrationEventRecorder` becomes `EventRecorder`

I've also taken the opportunity to start wording the documentation more like a specification.

Fixes #43