### PR TITLE
State that `AggregateRoot.ApplyEvent()` is for events recorded against this specific instance.

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -58,8 +58,8 @@ type AggregateMessageHandler interface {
 // AggregateRoot is an interface implemented by the application and used by
 // the engine to apply changes to an aggregate instance.
 type AggregateRoot interface {
-	// ApplyEvent updates the aggregate instance to reflect the fact that a
-	// particular domain event has occurred.
+	// ApplyEvent updates the aggregate instance to reflect the occurence of an
+	// event that was recorded against this instance.
 	ApplyEvent(m Message)
 }
 


### PR DESCRIPTION
In response to https://github.com/dogmatiq/example/pull/6#discussion_r254505304.