### PR TITLE
Implement unique application and handler keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Applications and handlers are now assigned an immutable "key"
+
+### Changed
+
+- **[BC]** Replace configure `Name()` methods with `Identity()`
+
 ## [0.4.0]
 
 ### Added

--- a/aggregate.go
+++ b/aggregate.go
@@ -94,18 +94,28 @@ type AggregateRoot interface {
 // In the context of this interface, "the handler" refers to the handler on
 // which Configure() has been called.
 type AggregateConfigurer interface {
-	// Name sets the name of the handler.
+	// Identity sets unique identifiers for the handler.
 	//
 	// It MUST be called exactly once within a single call to Configure().
 	//
-	// The name MUST be a non-empty UTF-8 string consisting solely of printable
-	// Unicode characters, excluding whitespace. A printable character is any
-	// character from the Letter, Mark, Number, Punctuation or Symbol
-	// categories.
+	// The name is a human-readable identifier for the handler. Each handler
+	// within an application MUST have a unique name. Handler names SHOULD be
+	// distinct from the application's name. The name MAY be changed over time
+	// to best reflect the purpose of the handler.
 	//
-	// Each handler within an application MUST have a unique name. Although not
-	// recommended, a handler MAY share its name with the application itself.
-	Name(n string)
+	// The key is an immutable identifier for the handler. Its purpose is to
+	// allow engine implementations to associate ancillary data with the
+	// handler, such as application state or message routing information.
+	//
+	// The application and the handlers within it MUST have distinct keys. The
+	// key MUST NOT be changed. The RECOMMENDED key format is RFC 4122 UUID,
+	// generated when the handler is first implemented.
+	//
+	// Both the name and the key MUST be non-empty UTF-8 strings consisting
+	// solely of printable Unicode characters, excluding whitespace. A printable
+	// character is any character from the Letter, Mark, Number, Punctuation or
+	// Symbol categories.
+	Identity(name string, key string)
 
 	// ConsumesCommandType configures the engine to route command messages of
 	// the same type as m to the handler.

--- a/application.go
+++ b/application.go
@@ -17,18 +17,29 @@ type Application interface {
 // It is passed to Application.Configure(), typically upon initialization of the
 // engine.
 type ApplicationConfigurer interface {
-	// Name sets the name of the application.
+	// Identity sets unique identifiers for the application.
 	//
 	// It MUST be called exactly once within a single call to Configure().
 	//
-	// The name MUST be a non-empty UTF-8 string consisting solely of printable
-	// Unicode characters, excluding whitespace. A printable character is any
-	// character from the Letter, Mark, Number, Punctuation or Symbol
-	// categories.
+	// The name is a human-readable identifier for the application. The
+	// application name SHOULD be distinct from that of any handlers within the
+	// application. The name MAY be changed over time to best reflect the
+	// purpose of the application.
 	//
-	// Although not recommended, the application MAY share its name with one of
-	// its handlers.
-	Name(n string)
+	// The key is an immutable identifier for the application. Its purpose is to
+	// allow engine implementations to uniquely identify the application in a
+	// multi-application environment, and to associate ancillary data with the
+	// application, such as message routing information.
+	//
+	// The application and the handlers within it MUST have distinct keys. The
+	// key MUST NOT be changed. The RECOMMENDED key format is RFC 4122 UUID,
+	// generated when the handler is first implemented.
+	//
+	// Both the name and the key MUST be non-empty UTF-8 strings consisting
+	// solely of printable Unicode characters, excluding whitespace. A printable
+	// character is any character from the Letter, Mark, Number, Punctuation or
+	// Symbol categories.
+	Identity(name string, key string)
 
 	// RegisterAggregate configures the engine to route messages to h.
 	RegisterAggregate(h AggregateMessageHandler)

--- a/docs/adr/0009-immutable-keys.md
+++ b/docs/adr/0009-immutable-keys.md
@@ -24,8 +24,8 @@ implementation changes.
 We've decided to add an additional identifier to applications and handlers
 called the "key".
 
-The key's express purpose is for identifying associated data, and as such as
-more stringent requirements on its immutability.
+The key's express purpose is for identifying associated data, and therefore has
+more stringent requirements on its immutability than the name.
 
 We further recommend the use of an [RFC 4122] UUID as the format of all keys.
 UUIDs can be generated at the time the application or handler is first

--- a/docs/adr/0009-immutable-keys.md
+++ b/docs/adr/0009-immutable-keys.md
@@ -1,0 +1,46 @@
+# 9. Immutable Application and Handler Keys
+
+Date: 2019-06-28
+
+## Status
+
+Accepted
+
+## Context
+
+Engine implementations require a mechanism for associating ancillary data with
+Dogma applications and handlers.
+
+For example, such data might include application state in the form of aggregate
+and process roots, or historical events in an event sourcing system.
+
+Currently, engine implementations rely on application and handler names as a key
+for associated data. This is especially problematic for handlers as the name
+initially chosen for a handler may become misleading over time as the handler's
+implementation changes.
+
+## Decision
+
+We've decided to add an additional identifier to applications and handlers
+called the "key".
+
+The key's express purpose is for identifying associated data, and as such as
+more stringent requirements on its immutability.
+
+We further recommend the use of an [RFC 4122] UUID as the format of all keys.
+UUIDs can be generated at the time the application or handler is first
+implemented. Many IDEs support generation of UUIDs.
+
+Applications and handlers retain their names as a human-readable identifier.
+
+## Consequences
+
+The addition of the key provides a reliable mechanism for associating data with
+applications and handlers. The consequences of changing a name or key are
+clearer.
+
+This does place some onus on the developer to generate a unique key and to
+maintain the same key for the lifetime of the handler implementation.
+
+<!-- references -->
+[RFC 4122]: https://tools.ietf.org/html/rfc4122

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,3 +18,4 @@ the ADR documents.
 * [6. Stateless aggregates and processes](0006-stateless-aggregates-and-processes.md)
 * [7. Location of Examples](0007-location-of-examples.md)
 * [8. Location of Testing Features](0008-location-of-testing-features.md)
+* [9. Immutable Application and Handler Keys](0009-immutable-keys.md)

--- a/integration.go
+++ b/integration.go
@@ -47,18 +47,28 @@ type IntegrationMessageHandler interface {
 // In the context of this interface, "the handler" refers to the handler on
 // which Configure() has been called.
 type IntegrationConfigurer interface {
-	// Name sets the name of the handler.
+	// Identity sets unique identifiers for the handler.
 	//
 	// It MUST be called exactly once within a single call to Configure().
 	//
-	// The name MUST be a non-empty UTF-8 string consisting solely of printable
-	// Unicode characters, excluding whitespace. A printable character is any
-	// character from the Letter, Mark, Number, Punctuation or Symbol
-	// categories.
+	// The name is a human-readable identifier for the handler. Each handler
+	// within an application MUST have a unique name. Handler names SHOULD be
+	// distinct from the application's name. The name MAY be changed over time
+	// to best reflect the purpose of the handler.
 	//
-	// Each handler within an application MUST have a unique name. Although not
-	// recommended, a handler MAY share its name with the application itself.
-	Name(n string)
+	// The key is an immutable identifier for the handler. Its purpose is to
+	// allow engine implementations to associate ancillary data with the
+	// handler, such as application state or message routing information.
+	//
+	// The application and the handlers within it MUST have distinct keys. The
+	// key MUST NOT be changed. The RECOMMENDED key format is RFC 4122 UUID,
+	// generated when the handler is first implemented.
+	//
+	// Both the name and the key MUST be non-empty UTF-8 strings consisting
+	// solely of printable Unicode characters, excluding whitespace. A printable
+	// character is any character from the Letter, Mark, Number, Punctuation or
+	// Symbol categories.
+	Identity(name string, key string)
 
 	// ConsumesCommandType configures the engine to route command messages of
 	// the same type as m to the handler.

--- a/process.go
+++ b/process.go
@@ -110,18 +110,28 @@ type ProcessRoot interface {
 // In the context of this interface, "the handler" refers to the handler on
 // which Configure() has been called.
 type ProcessConfigurer interface {
-	// Name sets the name of the handler.
+	// Identity sets unique identifiers for the handler.
 	//
 	// It MUST be called exactly once within a single call to Configure().
 	//
-	// The name MUST be a non-empty UTF-8 string consisting solely of printable
-	// Unicode characters, excluding whitespace. A printable character is any
-	// character from the Letter, Mark, Number, Punctuation or Symbol
-	// categories.
+	// The name is a human-readable identifier for the handler. Each handler
+	// within an application MUST have a unique name. Handler names SHOULD be
+	// distinct from the application's name. The name MAY be changed over time
+	// to best reflect the purpose of the handler.
 	//
-	// Each handler within an application MUST have a unique name. Although not
-	// recommended, a handler MAY share its name with the application itself.
-	Name(n string)
+	// The key is an immutable identifier for the handler. Its purpose is to
+	// allow engine implementations to associate ancillary data with the
+	// handler, such as application state or message routing information.
+	//
+	// The application and the handlers within it MUST have distinct keys. The
+	// key MUST NOT be changed. The RECOMMENDED key format is RFC 4122 UUID,
+	// generated when the handler is first implemented.
+	//
+	// Both the name and the key MUST be non-empty UTF-8 strings consisting
+	// solely of printable Unicode characters, excluding whitespace. A printable
+	// character is any character from the Letter, Mark, Number, Punctuation or
+	// Symbol categories.
+	Identity(name string, key string)
 
 	// ConsumesEventType configures the engine to route event messages of the
 	// same type as m to the handler.

--- a/projection.go
+++ b/projection.go
@@ -56,18 +56,28 @@ type ProjectionMessageHandler interface {
 // In the context of this interface, "the handler" refers to the handler on
 // which Configure() has been called.
 type ProjectionConfigurer interface {
-	// Name sets the name of the handler.
+	// Identity sets unique identifiers for the handler.
 	//
 	// It MUST be called exactly once within a single call to Configure().
 	//
-	// The name MUST be a non-empty UTF-8 string consisting solely of printable
-	// Unicode characters, excluding whitespace. A printable character is any
-	// character from the Letter, Mark, Number, Punctuation or Symbol
-	// categories.
+	// The name is a human-readable identifier for the handler. Each handler
+	// within an application MUST have a unique name. Handler names SHOULD be
+	// distinct from the application's name. The name MAY be changed over time
+	// to best reflect the purpose of the handler.
 	//
-	// Each handler within an application MUST have a unique name. Although not
-	// recommended, a handler MAY share its name with the application itself.
-	Name(n string)
+	// The key is an immutable identifier for the handler. Its purpose is to
+	// allow engine implementations to associate ancillary data with the
+	// handler, such as application state or message routing information.
+	//
+	// The application and the handlers within it MUST have distinct keys. The
+	// key MUST NOT be changed. The RECOMMENDED key format is RFC 4122 UUID,
+	// generated when the handler is first implemented.
+	//
+	// Both the name and the key MUST be non-empty UTF-8 strings consisting
+	// solely of printable Unicode characters, excluding whitespace. A printable
+	// character is any character from the Letter, Mark, Number, Punctuation or
+	// Symbol categories.
+	Identity(name string, key string)
 
 	// ConsumesEventType configures the engine to route event messages of the
 	// same type as m to the handler.


### PR DESCRIPTION
Fixes #85

This change introduces the concept of unique "keys", distinct from application and handler names, as described in ADR-9.

