### PR TITLE
Handler timeout hints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,14 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Added
 
 - Applications and handlers are now assigned an immutable "key"
+- **[BC]** Add `ProcessHandler.TimeoutHint()`
+- **[BC]** Add `IntegrationHandler.TimeoutHint()`
+- **[BC]** Add `ProjectionHandler.TimeoutHint()`
 
 ### Changed
 
 - **[BC]** Replace configure `Name()` methods with `Identity()`
-- **[BC]** Renamed `NoTimeoutBehavior` to `NoTimeoutMessagesBehavior`
+- **[BC]** Rename `NoTimeoutBehavior` to `NoTimeoutMessagesBehavior`
 
 ## [0.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 - **[BC]** Add `ProcessHandler.TimeoutHint()`
 - **[BC]** Add `IntegrationHandler.TimeoutHint()`
 - **[BC]** Add `ProjectionHandler.TimeoutHint()`
+- Add `NoTimeoutHintBehavior`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Changed
 
 - **[BC]** Replace configure `Name()` methods with `Identity()`
+- **[BC]** Renamed `NoTimeoutBehavior` to `NoTimeoutMessagesBehavior`
 
 ## [0.4.0]
 
 ### Added
 
-- Document what strings consititute valid application and handler names
+- Document what strings constitute valid application and handler names
 - **[BC]** Add `ProcessConfigurer.SchedulesTimeoutType()`
 
 ## [0.3.0] - 2019-02-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Added
 
 - Applications and handlers are now assigned an immutable "key"
-- **[BC]** Add `ProcessHandler.TimeoutHint()`
-- **[BC]** Add `IntegrationHandler.TimeoutHint()`
-- **[BC]** Add `ProjectionHandler.TimeoutHint()`
+- **[BC]** Add `ProcessMessageHandler.TimeoutHint()`
+- **[BC]** Add `IntegrationMessageHandler.TimeoutHint()`
+- **[BC]** Add `ProjectionMessageHandler.TimeoutHint()`
 - Add `NoTimeoutHintBehavior`
 
 ### Changed

--- a/docs/adr/0010-handler-timeout-hints.md
+++ b/docs/adr/0010-handler-timeout-hints.md
@@ -1,0 +1,40 @@
+# 10. Handler Timeout Hints
+
+Date: 2019-06-28
+
+## Status
+
+Accepted
+
+## Context
+
+We need to decide on a mechanism for engine implementations to determine
+suitable timeout durations to apply when handling a message.
+
+For aggregate message handlers, which are not permitted to access external
+resources, a fairly constant timeout duration should be discernable by the
+engine developers.
+
+For all other handler types, which may make network requests or perform CPU
+intensive work, there is no one timeout duration that makes sense in all
+circumstances.
+
+## Decision
+
+We have decided to allow process, integration and projection message handlers
+to provide a timeout "hint" on a per-message basis by way of a
+`TimeoutHint(dogma.Message) time.Duration` method.
+
+By returning a zero-value duration, the handler indicates that it can provide no
+useful "hint" and that the engine should choose a timeout by other means.
+
+## Consequences
+
+Engine portability is aided by including the timeout "hints" alongside the code
+that is subject to those timeouts.
+
+As always, such a change increases the complexity of the API.
+
+We did discuss leaving the configuration of timeouts as an engine-specific
+problem. However, we ultimately decided that the minor increase in API surface
+area is outweighed by the portability benefits.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,3 +19,4 @@ the ADR documents.
 * [7. Location of Examples](0007-location-of-examples.md)
 * [8. Location of Testing Features](0008-location-of-testing-features.md)
 * [9. Immutable Application and Handler Keys](0009-immutable-keys.md)
+* [10. Handler Timeout Hints](0010-handler-timeout-hints.md)

--- a/integration.go
+++ b/integration.go
@@ -31,7 +31,7 @@ type IntegrationMessageHandler interface {
 	//
 	// The supplied context parameter SHOULD have a deadline. The implementation
 	// SHOULD NOT impose its own deadline. Instead a suitable timeout duration
-	// can be suggested to the engine by via the handler's TimeoutHint() method.
+	// can be suggested to the engine via the handler's TimeoutHint() method.
 	//
 	// The engine MUST NOT call HandleCommand() with any message of a type that
 	// has not been configured for consumption by a prior call to Configure().

--- a/integration.go
+++ b/integration.go
@@ -1,6 +1,9 @@
 package dogma
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // IntegrationMessageHandler is an interface implemented by the application and
 // used by the engine to integrate with non-message-based systems.
@@ -26,6 +29,10 @@ type IntegrationMessageHandler interface {
 	// handler. That is, the engine should call HandleCommand() with the same
 	// command message until a nil error is returned.
 	//
+	// The supplied context parameter SHOULD have a deadline. The implementation
+	// SHOULD NOT impose its own deadline. Instead a suitable timeout duration
+	// can be suggested to the engine by via the handler's TimeoutHint() method.
+	//
 	// The engine MUST NOT call HandleCommand() with any message of a type that
 	// has not been configured for consumption by a prior call to Configure().
 	// If any such message is passed, the implementation MUST panic with the
@@ -36,6 +43,17 @@ type IntegrationMessageHandler interface {
 	//
 	// The engine MAY call HandleCommand() from multiple goroutines concurrently.
 	HandleCommand(ctx context.Context, s IntegrationCommandScope, m Message) error
+
+	// TimeoutHint returns a duration that is suitable for computing a deadline
+	// for the handling of the given message by this handler.
+	//
+	// The hint SHOULD be as short as possible. The implementation MAY return a
+	// zero-value to indicate that no hint can be made.
+	//
+	// The engine SHOULD use a duration as close as possible to the hint. Use of
+	// a duration shorter than the hint is NOT RECOMMENDED, as this will likely
+	// lead to repeated message handling failures.
+	TimeoutHint(m Message) time.Duration
 }
 
 // IntegrationConfigurer is an interface implemented by the engine and used

--- a/process.go
+++ b/process.go
@@ -64,7 +64,7 @@ type ProcessMessageHandler interface {
 	//
 	// The supplied context parameter SHOULD have a deadline. The implementation
 	// SHOULD NOT impose its own deadline. Instead a suitable timeout duration
-	// can be suggested to the engine by via the handler's TimeoutHint() method.
+	// can be suggested to the engine via the handler's TimeoutHint() method.
 	//
 	// The engine MUST NOT call HandleEvent() with any message of a type that
 	// has not been configured for consumption by a prior call to Configure().
@@ -88,7 +88,7 @@ type ProcessMessageHandler interface {
 	//
 	// The supplied context parameter SHOULD have a deadline. The implementation
 	// SHOULD NOT impose its own deadline. Instead a suitable timeout duration
-	// can be suggested to the engine by via the handler's TimeoutHint() method.
+	// can be suggested to the engine via the handler's TimeoutHint() method.
 	//
 	// The engine MUST NOT call HandleTimeout() with any message that was not
 	// scheduled by this handler. If any such message is passed, the

--- a/process.go
+++ b/process.go
@@ -308,14 +308,14 @@ var StatelessProcessRoot ProcessRoot = statelessProcessRoot{}
 
 type statelessProcessRoot struct{}
 
-// NoTimeoutBehavior can be embedded in ProcessMessageHandler implementations to
-// indicate that no timeout messages are used.
+// NoTimeoutMessagesBehavior can be embedded in ProcessMessageHandler
+// implementations to indicate that no timeout messages are used.
 //
-// It provides an implementation of ProcessMessageHandler.HandleTimeout() that always
-// panics with the UnexpectedMessage value.
-type NoTimeoutBehavior struct{}
+// It provides an implementation of ProcessMessageHandler.HandleTimeout() that
+// always panics with the UnexpectedMessage value.
+type NoTimeoutMessagesBehavior struct{}
 
-// HandleTimeout panic with the UnexpectedMessage value.
-func (NoTimeoutBehavior) HandleTimeout(context.Context, ProcessTimeoutScope, Message) error {
+// HandleTimeout panics with the UnexpectedMessage value.
+func (NoTimeoutMessagesBehavior) HandleTimeout(context.Context, ProcessTimeoutScope, Message) error {
 	panic(UnexpectedMessage)
 }

--- a/process.go
+++ b/process.go
@@ -62,6 +62,10 @@ type ProcessMessageHandler interface {
 	// handler. That is, the engine should call HandleEvent() with the same
 	// event message until a nil error is returned.
 	//
+	// The supplied context parameter SHOULD have a deadline. The implementation
+	// SHOULD NOT impose its own deadline. Instead a suitable timeout duration
+	// can be suggested to the engine by via the handler's TimeoutHint() method.
+	//
 	// The engine MUST NOT call HandleEvent() with any message of a type that
 	// has not been configured for consumption by a prior call to Configure().
 	// If any such message is passed, the implementation MUST panic with the
@@ -82,6 +86,10 @@ type ProcessMessageHandler interface {
 	// example, an application might use a timeout to mark an invoice as overdue
 	// after some period of non-payment.
 	//
+	// The supplied context parameter SHOULD have a deadline. The implementation
+	// SHOULD NOT impose its own deadline. Instead a suitable timeout duration
+	// can be suggested to the engine by via the handler's TimeoutHint() method.
+	//
 	// The engine MUST NOT call HandleTimeout() with any message that was not
 	// scheduled by this handler. If any such message is passed, the
 	// implementation MUST panic with the UnexpectedMessage value.
@@ -94,6 +102,17 @@ type ProcessMessageHandler interface {
 	// timeout message was scheduled. It SHOULD attempt to call HandleTimeout()
 	// as soon as the scheduled time is reached.
 	HandleTimeout(ctx context.Context, s ProcessTimeoutScope, m Message) error
+
+	// TimeoutHint returns a duration that is suitable for computing a deadline
+	// for the handling of the given message by this handler.
+	//
+	// The hint SHOULD be as short as possible. The implementation MAY return a
+	// zero-value to indicate that no hint can be made.
+	//
+	// The engine SHOULD use a duration as close as possible to the hint. Use of
+	// a duration shorter than the hint is NOT RECOMMENDED, as this will likely
+	// lead to repeated message handling failures.
+	TimeoutHint(m Message) time.Duration
 }
 
 // ProcessRoot is an interface implemented by the application and used by

--- a/process_test.go
+++ b/process_test.go
@@ -17,8 +17,8 @@ func TestStatelessProcessBehavior_New_ReturnsStatelessProcessRoot(t *testing.T) 
 	}
 }
 
-func TestNoTimeoutBehavior_HandleTimeout_Panics(t *testing.T) {
-	var v NoTimeoutBehavior
+func TestNoTimeoutMessagesBehavior_HandleTimeout_Panics(t *testing.T) {
+	var v NoTimeoutMessagesBehavior
 	ctx := context.Background()
 
 	defer func() {

--- a/projection.go
+++ b/projection.go
@@ -35,7 +35,7 @@ type ProjectionMessageHandler interface {
 	//
 	// The supplied context parameter SHOULD have a deadline. The implementation
 	// SHOULD NOT impose its own deadline. Instead a suitable timeout duration
-	// can be suggested to the engine by via the handler's TimeoutHint() method.
+	// can be suggested to the engine via the handler's TimeoutHint() method.
 	//
 	// The engine MUST NOT call HandleEvent() with any message of a type that
 	// has not been configured for consumption by a prior call to Configure().

--- a/projection.go
+++ b/projection.go
@@ -33,6 +33,10 @@ type ProjectionMessageHandler interface {
 	// handler. That is, the engine should call HandleEvent() with the same
 	// event message until a nil error is returned.
 	//
+	// The supplied context parameter SHOULD have a deadline. The implementation
+	// SHOULD NOT impose its own deadline. Instead a suitable timeout duration
+	// can be suggested to the engine by via the handler's TimeoutHint() method.
+	//
 	// The engine MUST NOT call HandleEvent() with any message of a type that
 	// has not been configured for consumption by a prior call to Configure().
 	// If any such message is passed, the implementation MUST panic with the
@@ -45,6 +49,17 @@ type ProjectionMessageHandler interface {
 	//
 	// The engine MAY call HandleEvent() from multiple goroutines concurrently.
 	HandleEvent(ctx context.Context, s ProjectionEventScope, m Message) error
+
+	// TimeoutHint returns a duration that is suitable for computing a deadline
+	// for the handling of the given message by this handler.
+	//
+	// The hint SHOULD be as short as possible. The implementation MAY return a
+	// zero-value to indicate that no hint can be made.
+	//
+	// The engine SHOULD use a duration as close as possible to the hint. Use of
+	// a duration shorter than the hint is NOT RECOMMENDED, as this will likely
+	// lead to repeated message handling failures.
+	TimeoutHint(m Message) time.Duration
 }
 
 // ProjectionConfigurer is an interface implemented by the engine and used by

--- a/timeout.go
+++ b/timeout.go
@@ -1,0 +1,18 @@
+package dogma
+
+import "time"
+
+// NoTimeoutHintBehavior can be embedded in message handler implementations
+// to indicate the handler is unable to suggest a message handling timeout duration.
+//
+// It provides an implementation of TimeoutHint() method that always returns
+// a zero value.
+//
+// The TimeoutHint() method is present in the ProcessMessageHandler,
+// IntegrationMessageHandler and ProjectionMessageHandler interfaces.
+type NoTimeoutHintBehavior struct{}
+
+// TimeoutHint always returns a zero-value duration.
+func (NoTimeoutHintBehavior) TimeoutHint(Message) time.Duration {
+	return 0
+}

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -1,0 +1,17 @@
+package dogma_test
+
+import (
+	"testing"
+
+	. "github.com/dogmatiq/dogma"
+)
+
+func TestNoTimeoutHintBehavior_TimeoutHint_ReturnsZero(t *testing.T) {
+	var v NoTimeoutHintBehavior
+
+	h := v.TimeoutHint(nil)
+
+	if h != 0 {
+		t.Fatal("unexpected value returned")
+	}
+}


### PR DESCRIPTION
This PR includes ADR-10, describing the decisions made around adding handler timeout hints.
There are no code changes just yet, please confirm the language of the ADR first.

**Update:** I've pushed the code changes.

- A `TimeoutHint()` method has been added to each of `ProcessMessageHandler`, `IntegrationMessageHandler` and `ProjectionMessageHandler`.
- I've added the `NoTimeoutHintBehavior` struct, which embeds a `TimeoutHint()` implementation that always returns `0`.
- The existing `NoTimeoutBehavior` struct has been renamed to `NoTimeoutMessagesBehavior` to avoid ambiguity.