### PR TITLE
Replace `ProjectionEventScope.Key()` with `MessageIdentity()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Changed
 
-- **[BC]** Replace configure `Name()` methods with `Identity()`
+- **[BC]** Replace configurer `Name()` methods with `Identity()`
+- **[BC]** Replace `ProjectionEventScope.Key()` with `MessageIdentity()`
 - **[BC]** Rename `NoTimeoutBehavior` to `NoTimeoutMessagesBehavior`
 - **[BC]** Rename `ProjectionEventScope.Time()` to `RecordedAt()`
 


### PR DESCRIPTION
Fixes #91