### PR TITLE
Add `DescribableMessage` interface and `DescribeMessage()`.

### DIFF
--- a/message.go
+++ b/message.go
@@ -1,5 +1,7 @@
 package dogma
 
+import "fmt"
+
 // A Message is an application-defined unit of data that encapsulates a
 // "command" or "event" within a message-based application.
 //
@@ -13,9 +15,46 @@ package dogma
 // The message implementations are provided by the application. The interface is
 // intentionally empty, allowing the use of any Go type as a message.
 //
+// Message implementations SHOULD implement fmt.Stringer or DescriableMessage in
+// order to provide a human-readable description of every message.
+//
 // Engine implementations MAY place further requirements upon message
 // implementations.
 type Message interface {
+}
+
+// DescribableMessage is a message that can provide a human-readable description
+// of itself.
+//
+// It can be implemented to provide a more specific message description for
+// message types that already implement fmt.Stringer, such as when the message
+// implementations are generated Protocol Buffers structs.
+type DescribableMessage interface {
+	Message
+
+	MessageDescription() string
+}
+
+// DescribeMessage returns a human-readable string representation of m.
+//
+// If m implements DescribableMessage, it returns m.MessageDescription().
+// Otherwise, if m implements fmt.Stringer, it returns m.String().
+//
+// Finally, if m does not implement either of these interfaces, it returns the
+// standard Go "%v" representation of the message.
+//
+// Engine implementations SHOULD use the message description in logging and
+// other tracing systems to provide contextual information to developers.
+func DescribeMessage(m Message) string {
+	if s, ok := m.(DescribableMessage); ok {
+		return s.MessageDescription()
+	}
+
+	if s, ok := m.(fmt.Stringer); ok {
+		return s.String()
+	}
+
+	return fmt.Sprintf("%v", m)
 }
 
 // UnexpectedMessage is a panic value used by a message handler when it receives

--- a/message_test.go
+++ b/message_test.go
@@ -1,0 +1,48 @@
+package dogma_test
+
+import (
+	"testing"
+
+	. "github.com/dogmatiq/dogma"
+)
+
+type describable struct{}
+
+func (describable) MessageDescription() string {
+	return "<description>"
+}
+
+func (describable) String() string {
+	panic("unexpected call")
+}
+
+type stringer struct{}
+
+func (stringer) String() string {
+	return "<string>"
+}
+
+type indescribable struct {
+	Value int
+}
+
+func TestDescribeMessage_describable(t *testing.T) {
+	d := DescribeMessage(describable{})
+	if d != "<description>" {
+		t.Fatal("unexpected message description")
+	}
+}
+
+func TestDescribeMessage_stringer(t *testing.T) {
+	d := DescribeMessage(stringer{})
+	if d != "<string>" {
+		t.Fatal("unexpected message description")
+	}
+}
+
+func TestDescribeMessage_default(t *testing.T) {
+	d := DescribeMessage(indescribable{100})
+	if d != "{100}" {
+		t.Fatal("unexpected message description")
+	}
+}


### PR DESCRIPTION
Fixes #104 

This PR moves the notion of "self describing messages" out of `enginekit` and into a first-class `dogma` feature. It is implemented so as to remain compatibility with the `SelfDescribingMessage` implementation in `jmalloc/ax`.