### PR TITLE
Add test fixtures.

### DIFF
--- a/fixtures/aggregate.go
+++ b/fixtures/aggregate.go
@@ -1,0 +1,97 @@
+package fixtures
+
+import "github.com/dogmatiq/dogma"
+
+// AggregateRoot is a test implementation of dogma.AggregateRoot.
+type AggregateRoot struct {
+	Value          interface{}
+	ApplyEventFunc func(dogma.Message, interface{})
+}
+
+var _ dogma.AggregateRoot = &AggregateRoot{}
+
+// ApplyEvent updates the aggregate instance to reflect the fact that a
+// particular domain event has occurred.
+//
+// It calls v.ApplyEventFunc(m, v.Value)
+func (v *AggregateRoot) ApplyEvent(m dogma.Message) {
+	if v.ApplyEventFunc != nil {
+		v.ApplyEventFunc(m, v.Value)
+	}
+}
+
+// AggregateMessageHandler is a test implementation of dogma.AggregateMessageHandler.
+type AggregateMessageHandler struct {
+	NewFunc                    func() dogma.AggregateRoot
+	ConfigureFunc              func(dogma.AggregateConfigurer)
+	RouteCommandToInstanceFunc func(dogma.Message) string
+	HandleCommandFunc          func(dogma.AggregateCommandScope, dogma.Message)
+}
+
+var _ dogma.AggregateMessageHandler = &AggregateMessageHandler{}
+
+// New constructs a new aggregate instance and returns its root.
+//
+// If h.NewFunc is nil, it returns a new empty fixtures.AggregateRoot, otherwise
+// it calls h.NewFunc().
+func (h *AggregateMessageHandler) New() dogma.AggregateRoot {
+	if h.NewFunc != nil {
+		return h.NewFunc()
+	}
+
+	return &AggregateRoot{}
+}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+//
+// c provides access to the various configuration options, such as specifying
+// which types of domain command messages are routed to this handler.
+//
+// If h.ConfigureFunc is non-nil, it calls h.ConfigureFunc(c)
+func (h *AggregateMessageHandler) Configure(c dogma.AggregateConfigurer) {
+	if h.ConfigureFunc != nil {
+		h.ConfigureFunc(c)
+	}
+}
+
+// RouteCommandToInstance returns the ID of the aggregate instance that is
+// targetted by m.
+//
+// It panics with the UnexpectedMessage value if m is not one of the domain
+// command types that is routed to this handler via Configure().
+//
+// If h.RouteCommandToInstanceFunc is non-nil it returns the result of
+// h.RouteCommandToInstanceFunc(m), otherwise it panics.
+func (h *AggregateMessageHandler) RouteCommandToInstance(m dogma.Message) string {
+	if h.RouteCommandToInstanceFunc == nil {
+		panic(dogma.UnexpectedMessage)
+	}
+
+	return h.RouteCommandToInstanceFunc(m)
+}
+
+// HandleCommand handles a domain command message that has been routed to this
+// handler.
+//
+// Handling a domain command message involves inspecting the state of the
+// target aggregate instance to determine what changes, if any, should occur.
+// Each change is indicated by recording a domain event message.
+//
+// s provides access to the operations available within the scope of handling
+// m, such as creating or destroying the targeted instance, accessing its
+// state, and recording domain event messages.
+//
+// This method must not modify the targeted instance directly. All
+// modifications must be applied by the instance's ApplyEvent() method, which
+// is called for each domain event message that is recorded via s.
+//
+// It panics with the UnexpectedMessage value if m is not one of the domain
+// command types that is routed to this handler via Configure().
+//
+// If h.HandleCommandFunc is non-nil it calls h.HandleCommandFunc(s, m).
+func (h *AggregateMessageHandler) HandleCommand(s dogma.AggregateCommandScope, m dogma.Message) {
+	if h.HandleCommandFunc != nil {
+		h.HandleCommandFunc(s, m)
+	}
+}

--- a/fixtures/application.go
+++ b/fixtures/application.go
@@ -1,0 +1,23 @@
+package fixtures
+
+import "github.com/dogmatiq/dogma"
+
+// Application is a test implementation of dogma.Application.
+type Application struct {
+	ConfigureFunc func(dogma.ApplicationConfigurer)
+}
+
+var _ dogma.Application = &Application{}
+
+// Configure configures the behavior of the engine as it relates to this
+// application.
+//
+// c provides access to the various configuration options, such as specifying
+// which message handlers the application contains.
+//
+// If a.ConfigureFunc is non-nil, it calls a.ConfigureFunc(c)
+func (a *Application) Configure(c dogma.ApplicationConfigurer) {
+	if a.ConfigureFunc != nil {
+		a.ConfigureFunc(c)
+	}
+}

--- a/fixtures/doc.go
+++ b/fixtures/doc.go
@@ -1,0 +1,3 @@
+// Package fixtures is a set of test fixtures and mocks of the various Dogma
+// interfaces.
+package fixtures

--- a/fixtures/integration.go
+++ b/fixtures/integration.go
@@ -1,0 +1,64 @@
+package fixtures
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+)
+
+// IntegrationMessageHandler is a test implementation of dogma.IntegrationMessageHandler.
+type IntegrationMessageHandler struct {
+	ConfigureFunc     func(dogma.IntegrationConfigurer)
+	HandleCommandFunc func(context.Context, dogma.IntegrationCommandScope, dogma.Message) error
+	TimeoutHintFunc   func(m dogma.Message) time.Duration
+}
+
+var _ dogma.IntegrationMessageHandler = &IntegrationMessageHandler{}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+//
+// c provides access to the various configuration options, such as specifying
+// which types of integration command messages are routed to this handler.
+//
+// If h.ConfigureFunc is non-nil, it calls h.ConfigureFunc(c)
+func (h *IntegrationMessageHandler) Configure(c dogma.IntegrationConfigurer) {
+	if h.ConfigureFunc != nil {
+		h.ConfigureFunc(c)
+	}
+}
+
+// HandleCommand handles an integration command message that has been routed to
+// this handler.
+//
+// s provides access to the operations available within the scope of handling
+// m, such as publishing integration event messages.
+//
+// It panics with the UnexpectedMessage value if m is not one of the
+// integration command types that is routed to this handler via Configure().
+//
+// If h.HandleCommandFunc is non-nil it calls h.HandleCommandFunc(s, m).
+func (h *IntegrationMessageHandler) HandleCommand(
+	ctx context.Context,
+	s dogma.IntegrationCommandScope,
+	m dogma.Message,
+) error {
+	if h.HandleCommandFunc != nil {
+		return h.HandleCommandFunc(ctx, s, m)
+	}
+
+	return nil
+}
+
+// TimeoutHint returns a duration that is suitable for computing a deadline
+// for the handling of the given message by this handler.
+//
+// If h.TimeoutHintFunc is non-nil it calls h.TimeoutHintFunc(m).
+func (h *IntegrationMessageHandler) TimeoutHint(m dogma.Message) time.Duration {
+	if h.TimeoutHintFunc != nil {
+		return h.TimeoutHintFunc(m)
+	}
+
+	return 0
+}

--- a/fixtures/message.go
+++ b/fixtures/message.go
@@ -1,0 +1,365 @@
+package fixtures
+
+// MessageA is type used as a dogma.Message in tests.
+type MessageA struct {
+	Value interface{}
+}
+
+var (
+	// MessageA1 is an instance of MessageA with a distinct value to be used in tests.
+	MessageA1 = MessageA{"A1"}
+	// MessageA2 is an instance of MessageA with a distinct value to be used in tests.
+	MessageA2 = MessageA{"A2"}
+	// MessageA3 is an instance of MessageA with a distinct value to be used in tests.
+	MessageA3 = MessageA{"A3"}
+)
+
+// MessageB is type used as a dogma.Message in tests.
+type MessageB struct {
+	Value interface{}
+}
+
+var (
+	// MessageB1 is an instance of MessageB with a distinct value to be used in tests.
+	MessageB1 = MessageB{"B1"}
+	// MessageB2 is an instance of MessageB with a distinct value to be used in tests.
+	MessageB2 = MessageB{"B2"}
+	// MessageB3 is an instance of MessageB with a distinct value to be used in tests.
+	MessageB3 = MessageB{"B3"}
+)
+
+// MessageC is type used as a dogma.Message in tests.
+type MessageC struct {
+	Value interface{}
+}
+
+var (
+	// MessageC1 is an instance of MessageC with a distinct value to be used in tests.
+	MessageC1 = MessageC{"C1"}
+	// MessageC2 is an instance of MessageC with a distinct value to be used in tests.
+	MessageC2 = MessageC{"C2"}
+	// MessageC3 is an instance of MessageC with a distinct value to be used in tests.
+	MessageC3 = MessageC{"C3"}
+)
+
+// MessageD is type used as a dogma.Message in tests.
+type MessageD struct {
+	Value interface{}
+}
+
+var (
+	// MessageD1 is an instance of MessageD with a distinct value to be used in tests.
+	MessageD1 = MessageD{"D1"}
+	// MessageD2 is an instance of MessageD with a distinct value to be used in tests.
+	MessageD2 = MessageD{"D2"}
+	// MessageD3 is an instance of MessageD with a distinct value to be used in tests.
+	MessageD3 = MessageD{"D3"}
+)
+
+// MessageE is type used as a dogma.Message in tests.
+type MessageE struct {
+	Value interface{}
+}
+
+var (
+	// MessageE1 is an instance of MessageE with a distinct value to be used in tests.
+	MessageE1 = MessageE{"E1"}
+	// MessageE2 is an instance of MessageE with a distinct value to be used in tests.
+	MessageE2 = MessageE{"E2"}
+	// MessageE3 is an instance of MessageE with a distinct value to be used in tests.
+	MessageE3 = MessageE{"E3"}
+)
+
+// MessageF is type used as a dogma.Message in tests.
+type MessageF struct {
+	Value interface{}
+}
+
+var (
+	// MessageF1 is an instance of MessageF with a distinct value to be used in tests.
+	MessageF1 = MessageF{"F1"}
+	// MessageF2 is an instance of MessageF with a distinct value to be used in tests.
+	MessageF2 = MessageF{"F2"}
+	// MessageF3 is an instance of MessageF with a distinct value to be used in tests.
+	MessageF3 = MessageF{"F3"}
+)
+
+// MessageG is type used as a dogma.Message in tests.
+type MessageG struct {
+	Value interface{}
+}
+
+var (
+	// MessageG1 is an instance of MessageG with a distinct value to be used in tests.
+	MessageG1 = MessageG{"G1"}
+	// MessageG2 is an instance of MessageG with a distinct value to be used in tests.
+	MessageG2 = MessageG{"G2"}
+	// MessageG3 is an instance of MessageG with a distinct value to be used in tests.
+	MessageG3 = MessageG{"G3"}
+)
+
+// MessageH is type used as a dogma.Message in tests.
+type MessageH struct {
+	Value interface{}
+}
+
+var (
+	// MessageH1 is an instance of MessageH with a distinct value to be used in tests.
+	MessageH1 = MessageH{"H1"}
+	// MessageH2 is an instance of MessageH with a distinct value to be used in tests.
+	MessageH2 = MessageH{"H2"}
+	// MessageH3 is an instance of MessageH with a distinct value to be used in tests.
+	MessageH3 = MessageH{"H3"}
+)
+
+// MessageI is type used as a dogma.Message in tests.
+type MessageI struct {
+	Value interface{}
+}
+
+var (
+	// MessageI1 is an instance of MessageI with a distinct value to be used in tests.
+	MessageI1 = MessageI{"I1"}
+	// MessageI2 is an instance of MessageI with a distinct value to be used in tests.
+	MessageI2 = MessageI{"I2"}
+	// MessageI3 is an instance of MessageI with a distinct value to be used in tests.
+	MessageI3 = MessageI{"I3"}
+)
+
+// MessageJ is type used as a dogma.Message in tests.
+type MessageJ struct {
+	Value interface{}
+}
+
+var (
+	// MessageJ1 is an instance of MessageJ with a distinct value to be used in tests.
+	MessageJ1 = MessageJ{"J1"}
+	// MessageJ2 is an instance of MessageJ with a distinct value to be used in tests.
+	MessageJ2 = MessageJ{"J2"}
+	// MessageJ3 is an instance of MessageJ with a distinct value to be used in tests.
+	MessageJ3 = MessageJ{"J3"}
+)
+
+// MessageK is type used as a dogma.Message in tests.
+type MessageK struct {
+	Value interface{}
+}
+
+var (
+	// MessageK1 is an instance of MessageK with a distinct value to be used in tests.
+	MessageK1 = MessageK{"K1"}
+	// MessageK2 is an instance of MessageK with a distinct value to be used in tests.
+	MessageK2 = MessageK{"K2"}
+	// MessageK3 is an instance of MessageK with a distinct value to be used in tests.
+	MessageK3 = MessageK{"K3"}
+)
+
+// MessageL is type used as a dogma.Message in tests.
+type MessageL struct {
+	Value interface{}
+}
+
+var (
+	// MessageL1 is an instance of MessageL with a distinct value to be used in tests.
+	MessageL1 = MessageL{"L1"}
+	// MessageL2 is an instance of MessageL with a distinct value to be used in tests.
+	MessageL2 = MessageL{"L2"}
+	// MessageL3 is an instance of MessageL with a distinct value to be used in tests.
+	MessageL3 = MessageL{"L3"}
+)
+
+// MessageM is type used as a dogma.Message in tests.
+type MessageM struct {
+	Value interface{}
+}
+
+var (
+	// MessageM1 is an instance of MessageM with a distinct value to be used in tests.
+	MessageM1 = MessageM{"M1"}
+	// MessageM2 is an instance of MessageM with a distinct value to be used in tests.
+	MessageM2 = MessageM{"M2"}
+	// MessageM3 is an instance of MessageM with a distinct value to be used in tests.
+	MessageM3 = MessageM{"M3"}
+)
+
+// MessageN is type used as a dogma.Message in tests.
+type MessageN struct {
+	Value interface{}
+}
+
+var (
+	// MessageN1 is an instance of MessageN with a distinct value to be used in tests.
+	MessageN1 = MessageN{"N1"}
+	// MessageN2 is an instance of MessageN with a distinct value to be used in tests.
+	MessageN2 = MessageN{"N2"}
+	// MessageN3 is an instance of MessageN with a distinct value to be used in tests.
+	MessageN3 = MessageN{"N3"}
+)
+
+// MessageO is type used as a dogma.Message in tests.
+type MessageO struct {
+	Value interface{}
+}
+
+var (
+	// MessageO1 is an instance of MessageO with a distinct value to be used in tests.
+	MessageO1 = MessageO{"O1"}
+	// MessageO2 is an instance of MessageO with a distinct value to be used in tests.
+	MessageO2 = MessageO{"O2"}
+	// MessageO3 is an instance of MessageO with a distinct value to be used in tests.
+	MessageO3 = MessageO{"O3"}
+)
+
+// MessageP is type used as a dogma.Message in tests.
+type MessageP struct {
+	Value interface{}
+}
+
+var (
+	// MessageP1 is an instance of MessageP with a distinct value to be used in tests.
+	MessageP1 = MessageP{"P1"}
+	// MessageP2 is an instance of MessageP with a distinct value to be used in tests.
+	MessageP2 = MessageP{"P2"}
+	// MessageP3 is an instance of MessageP with a distinct value to be used in tests.
+	MessageP3 = MessageP{"P3"}
+)
+
+// MessageQ is type used as a dogma.Message in tests.
+type MessageQ struct {
+	Value interface{}
+}
+
+var (
+	// MessageQ1 is an instance of MessageQ with a distinct value to be used in tests.
+	MessageQ1 = MessageQ{"Q1"}
+	// MessageQ2 is an instance of MessageQ with a distinct value to be used in tests.
+	MessageQ2 = MessageQ{"Q2"}
+	// MessageQ3 is an instance of MessageQ with a distinct value to be used in tests.
+	MessageQ3 = MessageQ{"Q3"}
+)
+
+// MessageR is type used as a dogma.Message in tests.
+type MessageR struct {
+	Value interface{}
+}
+
+var (
+	// MessageR1 is an instance of MessageR with a distinct value to be used in tests.
+	MessageR1 = MessageR{"R1"}
+	// MessageR2 is an instance of MessageR with a distinct value to be used in tests.
+	MessageR2 = MessageR{"R2"}
+	// MessageR3 is an instance of MessageR with a distinct value to be used in tests.
+	MessageR3 = MessageR{"R3"}
+)
+
+// MessageS is type used as a dogma.Message in tests.
+type MessageS struct {
+	Value interface{}
+}
+
+var (
+	// MessageS1 is an instance of MessageS with a distinct value to be used in tests.
+	MessageS1 = MessageS{"S1"}
+	// MessageS2 is an instance of MessageS with a distinct value to be used in tests.
+	MessageS2 = MessageS{"S2"}
+	// MessageS3 is an instance of MessageS with a distinct value to be used in tests.
+	MessageS3 = MessageS{"S3"}
+)
+
+// MessageT is type used as a dogma.Message in tests.
+type MessageT struct {
+	Value interface{}
+}
+
+var (
+	// MessageT1 is an instance of MessageT with a distinct value to be used in tests.
+	MessageT1 = MessageT{"T1"}
+	// MessageT2 is an instance of MessageT with a distinct value to be used in tests.
+	MessageT2 = MessageT{"T2"}
+	// MessageT3 is an instance of MessageT with a distinct value to be used in tests.
+	MessageT3 = MessageT{"T3"}
+)
+
+// MessageU is type used as a dogma.Message in tests.
+type MessageU struct {
+	Value interface{}
+}
+
+var (
+	// MessageU1 is an instance of MessageU with a distinct value to be used in tests.
+	MessageU1 = MessageU{"U1"}
+	// MessageU2 is an instance of MessageU with a distinct value to be used in tests.
+	MessageU2 = MessageU{"U2"}
+	// MessageU3 is an instance of MessageU with a distinct value to be used in tests.
+	MessageU3 = MessageU{"U3"}
+)
+
+// MessageV is type used as a dogma.Message in tests.
+type MessageV struct {
+	Value interface{}
+}
+
+var (
+	// MessageV1 is an instance of MessageV with a distinct value to be used in tests.
+	MessageV1 = MessageV{"V1"}
+	// MessageV2 is an instance of MessageV with a distinct value to be used in tests.
+	MessageV2 = MessageV{"V2"}
+	// MessageV3 is an instance of MessageV with a distinct value to be used in tests.
+	MessageV3 = MessageV{"V3"}
+)
+
+// MessageW is type used as a dogma.Message in tests.
+type MessageW struct {
+	Value interface{}
+}
+
+var (
+	// MessageW1 is an instance of MessageW with a distinct value to be used in tests.
+	MessageW1 = MessageW{"W1"}
+	// MessageW2 is an instance of MessageW with a distinct value to be used in tests.
+	MessageW2 = MessageW{"W2"}
+	// MessageW3 is an instance of MessageW with a distinct value to be used in tests.
+	MessageW3 = MessageW{"W3"}
+)
+
+// MessageX is type used as a dogma.Message in tests.
+type MessageX struct {
+	Value interface{}
+}
+
+var (
+	// MessageX1 is an instance of MessageX with a distinct value to be used in tests.
+	MessageX1 = MessageX{"X1"}
+	// MessageX2 is an instance of MessageX with a distinct value to be used in tests.
+	MessageX2 = MessageX{"X2"}
+	// MessageX3 is an instance of MessageX with a distinct value to be used in tests.
+	MessageX3 = MessageX{"X3"}
+)
+
+// MessageY is type used as a dogma.Message in tests.
+type MessageY struct {
+	Value interface{}
+}
+
+var (
+	// MessageY1 is an instance of MessageY with a distinct value to be used in tests.
+	MessageY1 = MessageY{"Y1"}
+	// MessageY2 is an instance of MessageY with a distinct value to be used in tests.
+	MessageY2 = MessageY{"Y2"}
+	// MessageY3 is an instance of MessageY with a distinct value to be used in tests.
+	MessageY3 = MessageY{"Y3"}
+)
+
+// MessageZ is type used as a dogma.Message in tests.
+type MessageZ struct {
+	Value interface{}
+}
+
+var (
+	// MessageZ1 is an instance of MessageZ with a distinct value to be used in tests.
+	MessageZ1 = MessageZ{"Z1"}
+	// MessageZ2 is an instance of MessageZ with a distinct value to be used in tests.
+	MessageZ2 = MessageZ{"Z2"}
+	// MessageZ3 is an instance of MessageZ with a distinct value to be used in tests.
+	MessageZ3 = MessageZ{"Z3"}
+)

--- a/fixtures/process.go
+++ b/fixtures/process.go
@@ -1,0 +1,142 @@
+package fixtures
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+)
+
+// ProcessRoot is a test implementation of dogma.ProcessRoot.
+type ProcessRoot struct {
+	Value interface{}
+}
+
+var _ dogma.ProcessRoot = &ProcessRoot{}
+
+// ProcessMessageHandler is a test implementation of dogma.ProcessMessageHandler.
+type ProcessMessageHandler struct {
+	NewFunc                  func() dogma.ProcessRoot
+	ConfigureFunc            func(dogma.ProcessConfigurer)
+	RouteEventToInstanceFunc func(context.Context, dogma.Message) (string, bool, error)
+	HandleEventFunc          func(context.Context, dogma.ProcessEventScope, dogma.Message) error
+	HandleTimeoutFunc        func(context.Context, dogma.ProcessTimeoutScope, dogma.Message) error
+	TimeoutHintFunc          func(m dogma.Message) time.Duration
+}
+
+var _ dogma.ProcessMessageHandler = &ProcessMessageHandler{}
+
+// New constructs a new process instance and returns its root.
+//
+// If h.NewFunc is nil, it returns a new empty fixtures.ProcessRoot, otherwise
+// it calls h.NewFunc().
+func (h *ProcessMessageHandler) New() dogma.ProcessRoot {
+	if h.NewFunc != nil {
+		return h.NewFunc()
+	}
+
+	return &ProcessRoot{}
+}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+//
+// c provides access to the various configuration options, such as
+// specifying which types of event messages are routed to this handler.
+//
+// If h.ConfigureFunc is non-nil, it calls h.ConfigureFunc(c)
+func (h *ProcessMessageHandler) Configure(c dogma.ProcessConfigurer) {
+	if h.ConfigureFunc != nil {
+		h.ConfigureFunc(c)
+	}
+}
+
+// RouteEventToInstance returns the ID of the process instance that is
+// targetted by m.
+//
+// It panics with the UnexpectedMessage value if m is not one of the event
+// types that is routed to this handler via Configure().
+//
+// If ok is false, the message is not routed to this handler at all.
+//
+// If h.RouteEventToInstance is non-nil it returns the result of
+// h.RouteEventToInstance(ctx, m), otherwise it panics.
+func (h *ProcessMessageHandler) RouteEventToInstance(
+	ctx context.Context,
+	m dogma.Message,
+) (string, bool, error) {
+	if h.RouteEventToInstanceFunc == nil {
+		panic(dogma.UnexpectedMessage)
+	}
+
+	return h.RouteEventToInstanceFunc(ctx, m)
+}
+
+// HandleEvent handles an event message that has been routed to this
+// handler.
+//
+// Handling an event message involves inspecting the state of the target
+// process instance to determine what command messages, if any, should be
+// produced.
+//
+// s provides access to the operations available within the scope of handling
+// m, such as beginning or ending the targeted instance, accessing its state,
+// sending command messages or scheduling timeouts.
+//
+// This method may manipulate the process's state directly.
+//
+// It panics with the UnexpectedMessage value if m is not one of the event
+// types that is routed to this handler via Configure().
+//
+// If h.HandleEventFunc is non-nil it calls h.HandleEventFunc(ctx, s, m).
+func (h *ProcessMessageHandler) HandleEvent(
+	ctx context.Context,
+	s dogma.ProcessEventScope,
+	m dogma.Message,
+) error {
+	if h.HandleEventFunc != nil {
+		return h.HandleEventFunc(ctx, s, m)
+	}
+
+	return nil
+}
+
+// HandleTimeout handles a timeout message that has been scheduled with
+// ProcessScope.ScheduleTimeout().
+//
+// Timeouts can be used to model time within the domain. For example, an
+// application might use a timeout to mark an invoice as overdue after some
+// period of non-payment.
+//
+// Handling a timeout is much like handling an event in that much the same
+// operations are available to the handler via s.
+//
+// This method may manipulate the process's state directly.
+//
+// If m was not expected by the handler the implementation must panic with an
+// UnexpectedMessage value.
+//
+// If h.HandleTimeoutFunc is non-nil it calls h.HandleTimeoutFunc(ctx, s, m).
+func (h *ProcessMessageHandler) HandleTimeout(
+	ctx context.Context,
+	s dogma.ProcessTimeoutScope,
+	m dogma.Message,
+) error {
+	if h.HandleTimeoutFunc != nil {
+		return h.HandleTimeoutFunc(ctx, s, m)
+	}
+
+	return nil
+}
+
+// TimeoutHint returns a duration that is suitable for computing a deadline
+// for the handling of the given message by this handler.
+//
+// If h.TimeoutHintFunc is non-nil it calls h.TimeoutHintFunc(m).
+func (h *ProcessMessageHandler) TimeoutHint(m dogma.Message) time.Duration {
+	if h.TimeoutHintFunc != nil {
+		return h.TimeoutHintFunc(m)
+	}
+
+	return 0
+}

--- a/fixtures/projection.go
+++ b/fixtures/projection.go
@@ -39,7 +39,7 @@ func (h *ProjectionMessageHandler) Configure(c dogma.ProjectionConfigurer) {
 // It panics with the UnexpectedMessage value if m is not one of the event
 // types that is routed to this handler via Configure().
 //
-// If h.HandleEventFunc is non-nil it calls h.HandleEventFunc(ctx, r,c,n, s, m).
+// If h.HandleEventFunc is non-nil it calls h.HandleEventFunc(ctx, r, c, n, s, m).
 func (h *ProjectionMessageHandler) HandleEvent(
 	ctx context.Context,
 	r, c, n []byte,
@@ -55,10 +55,10 @@ func (h *ProjectionMessageHandler) HandleEvent(
 
 // ResourceVersion returns the version of the resource r.
 //
-// If h.ResourceVersionFunc is non-nil it calls h.ResourceVersionFunc(ctx, k).
-func (h *ProjectionMessageHandler) ResourceVersion(ctx context.Context, k []byte) ([]byte, error) {
+// If h.ResourceVersionFunc is non-nil it calls h.ResourceVersionFunc(ctx, r).
+func (h *ProjectionMessageHandler) ResourceVersion(ctx context.Context, r []byte) ([]byte, error) {
 	if h.ResourceVersionFunc != nil {
-		return h.ResourceVersionFunc(ctx, k)
+		return h.ResourceVersionFunc(ctx, r)
 	}
 
 	return nil, nil
@@ -67,10 +67,10 @@ func (h *ProjectionMessageHandler) ResourceVersion(ctx context.Context, k []byte
 // CloseResource informs the projection that the resource r will not be used in
 // any future calls to HandleEvent().
 //
-// If h.CloseResourceFunc is non-nil it calls h.CloseResourceFunc(ctx, k).
-func (h *ProjectionMessageHandler) CloseResource(ctx context.Context, k []byte) error {
+// If h.CloseResourceFunc is non-nil it calls h.CloseResourceFunc(ctx, r).
+func (h *ProjectionMessageHandler) CloseResource(ctx context.Context, r []byte) error {
 	if h.CloseResourceFunc != nil {
-		return h.CloseResourceFunc(ctx, k)
+		return h.CloseResourceFunc(ctx, r)
 	}
 
 	return nil

--- a/fixtures/projection.go
+++ b/fixtures/projection.go
@@ -7,7 +7,8 @@ import (
 	"github.com/dogmatiq/dogma"
 )
 
-// ProjectionMessageHandler is a test implementation of dogma.ProjectionMessageHandler.
+// ProjectionMessageHandler is a test implementation of
+// dogma.ProjectionMessageHandler.
 type ProjectionMessageHandler struct {
 	ConfigureFunc       func(dogma.ProjectionConfigurer)
 	HandleEventFunc     func(context.Context, []byte, []byte, []byte, dogma.ProjectionEventScope, dogma.Message) (bool, error)
@@ -35,6 +36,9 @@ func (h *ProjectionMessageHandler) Configure(c dogma.ProjectionConfigurer) {
 // handler.
 //
 // s provides access to the operations available within the scope of handling m.
+//
+// r is an engine-defined OCC resource. c and n are the current and next
+// versions of that resource, respectively.
 //
 // It panics with the UnexpectedMessage value if m is not one of the event
 // types that is routed to this handler via Configure().

--- a/fixtures/projection.go
+++ b/fixtures/projection.go
@@ -1,0 +1,89 @@
+package fixtures
+
+import (
+	"context"
+	"time"
+
+	"github.com/dogmatiq/dogma"
+)
+
+// ProjectionMessageHandler is a test implementation of dogma.ProjectionMessageHandler.
+type ProjectionMessageHandler struct {
+	ConfigureFunc       func(dogma.ProjectionConfigurer)
+	HandleEventFunc     func(context.Context, []byte, []byte, []byte, dogma.ProjectionEventScope, dogma.Message) (bool, error)
+	ResourceVersionFunc func(context.Context, []byte) ([]byte, error)
+	CloseResourceFunc   func(context.Context, []byte) error
+	TimeoutHintFunc     func(m dogma.Message) time.Duration
+}
+
+var _ dogma.ProjectionMessageHandler = &ProjectionMessageHandler{}
+
+// Configure configures the behavior of the engine as it relates to this
+// handler.
+//
+// c provides access to the various configuration options, such as specifying
+// which types of event messages are routed to this handler.
+//
+// If h.ConfigureFunc is non-nil, it calls h.ConfigureFunc(c)
+func (h *ProjectionMessageHandler) Configure(c dogma.ProjectionConfigurer) {
+	if h.ConfigureFunc != nil {
+		h.ConfigureFunc(c)
+	}
+}
+
+// HandleEvent handles a domain event message that has been routed to this
+// handler.
+//
+// s provides access to the operations available within the scope of handling m.
+//
+// It panics with the UnexpectedMessage value if m is not one of the event
+// types that is routed to this handler via Configure().
+//
+// If h.HandleEventFunc is non-nil it calls h.HandleEventFunc(ctx, r,c,n, s, m).
+func (h *ProjectionMessageHandler) HandleEvent(
+	ctx context.Context,
+	r, c, n []byte,
+	s dogma.ProjectionEventScope,
+	m dogma.Message,
+) (bool, error) {
+	if h.HandleEventFunc != nil {
+		return h.HandleEventFunc(ctx, r, c, n, s, m)
+	}
+
+	return true, nil
+}
+
+// ResourceVersion returns the version of the resource r.
+//
+// If h.ResourceVersionFunc is non-nil it calls h.ResourceVersionFunc(ctx, k).
+func (h *ProjectionMessageHandler) ResourceVersion(ctx context.Context, k []byte) ([]byte, error) {
+	if h.ResourceVersionFunc != nil {
+		return h.ResourceVersionFunc(ctx, k)
+	}
+
+	return nil, nil
+}
+
+// CloseResource informs the projection that the resource r will not be used in
+// any future calls to HandleEvent().
+//
+// If h.CloseResourceFunc is non-nil it calls h.CloseResourceFunc(ctx, k).
+func (h *ProjectionMessageHandler) CloseResource(ctx context.Context, k []byte) error {
+	if h.CloseResourceFunc != nil {
+		return h.CloseResourceFunc(ctx, k)
+	}
+
+	return nil
+}
+
+// TimeoutHint returns a duration that is suitable for computing a deadline
+// for the handling of the given message by this handler.
+//
+// If h.TimeoutHintFunc is non-nil it calls h.TimeoutHintFunc(m).
+func (h *ProjectionMessageHandler) TimeoutHint(m dogma.Message) time.Duration {
+	if h.TimeoutHintFunc != nil {
+		return h.TimeoutHintFunc(m)
+	}
+
+	return 0
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/dogmatiq/dogma
 
-go 1.12
+go 1.13


### PR DESCRIPTION
These are the test fixtures from `dogmatiq/enginekit/fixtures`, minus the `config.MessageType` values, which depend on the `config` package from enginekit.

Fixes #106 (please read)

