### PR TITLE
Specify comparison semantics for identifiers.

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -108,13 +108,18 @@ type AggregateConfigurer interface {
 	// handler, such as application state or message routing information.
 	//
 	// The application and the handlers within it MUST have distinct keys. The
-	// key MUST NOT be changed. The RECOMMENDED key format is RFC 4122 UUID,
-	// generated when the handler is first implemented.
+	// key MUST NOT be changed. The RECOMMENDED key format is an RFC 4122 UUID
+	// represented as a hyphen-separated, lowercase hexadecimal string, such as
+	// "5195fe85-eb3f-4121-84b0-be72cbc5722f".
 	//
-	// Both the name and the key MUST be non-empty UTF-8 strings consisting
-	// solely of printable Unicode characters, excluding whitespace. A printable
-	// character is any character from the Letter, Mark, Number, Punctuation or
-	// Symbol categories.
+	// Both identifiers MUST be non-empty UTF-8 strings consisting solely of
+	// printable Unicode characters, excluding whitespace. A printable character
+	// is any character from the Letter, Mark, Number, Punctuation or Symbol
+	// categories.
+	//
+	// The engine MUST NOT perform any case-folding or normalization of
+	// identifiers. Therefore, two identifiers compare as equivalent if and only
+	// if they consist of the same sequence of bytes.
 	Identity(name string, key string)
 
 	// ConsumesCommandType configures the engine to route command messages of

--- a/application.go
+++ b/application.go
@@ -32,13 +32,18 @@ type ApplicationConfigurer interface {
 	// application, such as message routing information.
 	//
 	// The application and the handlers within it MUST have distinct keys. The
-	// key MUST NOT be changed. The RECOMMENDED key format is RFC 4122 UUID,
-	// generated when the handler is first implemented.
+	// key MUST NOT be changed. The RECOMMENDED key format is an RFC 4122 UUID
+	// represented as a hyphen-separated, lowercase hexadecimal string, such as
+	// "5195fe85-eb3f-4121-84b0-be72cbc5722f".
 	//
-	// Both the name and the key MUST be non-empty UTF-8 strings consisting
-	// solely of printable Unicode characters, excluding whitespace. A printable
-	// character is any character from the Letter, Mark, Number, Punctuation or
-	// Symbol categories.
+	// Both identifiers MUST be non-empty UTF-8 strings consisting solely of
+	// printable Unicode characters, excluding whitespace. A printable character
+	// is any character from the Letter, Mark, Number, Punctuation or Symbol
+	// categories.
+	//
+	// The engine MUST NOT perform any case-folding or normalization of
+	// identifiers. Therefore, two identifiers compare as equivalent if and only
+	// if they consist of the same sequence of bytes.
 	Identity(name string, key string)
 
 	// RegisterAggregate configures the engine to route messages to h.

--- a/docs/adr/0012-identifier-comparison.md
+++ b/docs/adr/0012-identifier-comparison.md
@@ -27,8 +27,8 @@ semantics for identifiers.
 ## Consequences
 
 Existing tooling and engine implementations, such as `configkit` and the
-in-memory engine implementation in `testkit` do not require changed. Identifiers
-can be compared using Go's standard comparison operators.
+in-memory engine implementation in `testkit` do not need to be changed.
+Identifiers can be compared using Go's standard comparison operators.
 
 It is possible that two identifiers may appear to be equal but consist of
 different byte sequences. For example, when a character with a diacritic mark is

--- a/docs/adr/0012-identifier-comparison.md
+++ b/docs/adr/0012-identifier-comparison.md
@@ -26,7 +26,7 @@ semantics for identifiers.
 
 ## Consequences
 
-Existing tooling and engine implementations, such as `configkit` and the the
+Existing tooling and engine implementations, such as `configkit` and the
 in-memory engine implementation in `testkit` do not require changed. Identifiers
 can be compared using Go's standard comparison operators.
 

--- a/docs/adr/0012-identifier-comparison.md
+++ b/docs/adr/0012-identifier-comparison.md
@@ -1,0 +1,38 @@
+# 12. Comparison of Identifiers
+
+Date: 2019-12-17
+
+## Status
+
+Accepted
+
+## Context
+
+Identifiers (the names and keys used to identify applications and handlers) must
+be compared by engines to determine if two such entities are to be considered
+equivalent.
+
+The documentation specifies that such keys must be non-empty UTF-8 strings
+consisting of printable characters without whitespace, but it did not previously
+specify how such strings would be compared.
+
+These identifiers are either mostly or entirely immutable and generated as part
+of the source code. They do not need to be parsed and validated from user input.
+
+## Decision
+
+In keeping with current behavior, we've decided to specify byte-wise comparison
+semantics for identifiers.
+
+## Consequences
+
+Existing tooling and engine implementations, such as `configkit` and the the
+in-memory engine implementation in `testkit` do not require changed. Identifiers
+can be compared using Go's standard comparison operators.
+
+It is possible that two identifiers may appear to be equal but consist of
+different byte sequences. For example, when a character with a diacritic mark is
+represented with a single codepoint, versus with combining characters. This is
+considered unlikely to present problems in practice, but nonetheless it is worth
+mentioning that the onus is on the application developer to normalize any UTF-8
+identifiers.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,3 +21,4 @@ the ADR documents.
 * [9. Immutable Application and Handler Keys](0009-immutable-keys.md)
 * [10. Handler Timeout Hints](0010-handler-timeout-hints.md)
 * [11. Message Timing Information](0011-message-timing-information.md)
+* [12. Comparison of Identifiers](0012-identifier-comparison.md)

--- a/integration.go
+++ b/integration.go
@@ -79,13 +79,18 @@ type IntegrationConfigurer interface {
 	// handler, such as application state or message routing information.
 	//
 	// The application and the handlers within it MUST have distinct keys. The
-	// key MUST NOT be changed. The RECOMMENDED key format is RFC 4122 UUID,
-	// generated when the handler is first implemented.
+	// key MUST NOT be changed. The RECOMMENDED key format is an RFC 4122 UUID
+	// represented as a hyphen-separated, lowercase hexadecimal string, such as
+	// "5195fe85-eb3f-4121-84b0-be72cbc5722f".
 	//
-	// Both the name and the key MUST be non-empty UTF-8 strings consisting
-	// solely of printable Unicode characters, excluding whitespace. A printable
-	// character is any character from the Letter, Mark, Number, Punctuation or
-	// Symbol categories.
+	// Both identifiers MUST be non-empty UTF-8 strings consisting solely of
+	// printable Unicode characters, excluding whitespace. A printable character
+	// is any character from the Letter, Mark, Number, Punctuation or Symbol
+	// categories.
+	//
+	// The engine MUST NOT perform any case-folding or normalization of
+	// identifiers. Therefore, two identifiers compare as equivalent if and only
+	// if they consist of the same sequence of bytes.
 	Identity(name string, key string)
 
 	// ConsumesCommandType configures the engine to route command messages of

--- a/process.go
+++ b/process.go
@@ -143,13 +143,18 @@ type ProcessConfigurer interface {
 	// handler, such as application state or message routing information.
 	//
 	// The application and the handlers within it MUST have distinct keys. The
-	// key MUST NOT be changed. The RECOMMENDED key format is RFC 4122 UUID,
-	// generated when the handler is first implemented.
+	// key MUST NOT be changed. The RECOMMENDED key format is an RFC 4122 UUID
+	// represented as a hyphen-separated, lowercase hexadecimal string, such as
+	// "5195fe85-eb3f-4121-84b0-be72cbc5722f".
 	//
-	// Both the name and the key MUST be non-empty UTF-8 strings consisting
-	// solely of printable Unicode characters, excluding whitespace. A printable
-	// character is any character from the Letter, Mark, Number, Punctuation or
-	// Symbol categories.
+	// Both identifiers MUST be non-empty UTF-8 strings consisting solely of
+	// printable Unicode characters, excluding whitespace. A printable character
+	// is any character from the Letter, Mark, Number, Punctuation or Symbol
+	// categories.
+	//
+	// The engine MUST NOT perform any case-folding or normalization of
+	// identifiers. Therefore, two identifiers compare as equivalent if and only
+	// if they consist of the same sequence of bytes.
 	Identity(name string, key string)
 
 	// ConsumesEventType configures the engine to route event messages of the

--- a/projection.go
+++ b/projection.go
@@ -139,13 +139,18 @@ type ProjectionConfigurer interface {
 	// handler, such as application state or message routing information.
 	//
 	// The application and the handlers within it MUST have distinct keys. The
-	// key MUST NOT be changed. The RECOMMENDED key format is RFC 4122 UUID,
-	// generated when the handler is first implemented.
+	// key MUST NOT be changed. The RECOMMENDED key format is an RFC 4122 UUID
+	// represented as a hyphen-separated, lowercase hexadecimal string, such as
+	// "5195fe85-eb3f-4121-84b0-be72cbc5722f".
 	//
-	// Both the name and the key MUST be non-empty UTF-8 strings consisting
-	// solely of printable Unicode characters, excluding whitespace. A printable
-	// character is any character from the Letter, Mark, Number, Punctuation or
-	// Symbol categories.
+	// Both identifiers MUST be non-empty UTF-8 strings consisting solely of
+	// printable Unicode characters, excluding whitespace. A printable character
+	// is any character from the Letter, Mark, Number, Punctuation or Symbol
+	// categories.
+	//
+	// The engine MUST NOT perform any case-folding or normalization of
+	// identifiers. Therefore, two identifiers compare as equivalent if and only
+	// if they consist of the same sequence of bytes.
 	Identity(name string, key string)
 
 	// ConsumesEventType configures the engine to route event messages of the


### PR DESCRIPTION
Fixes #110.

This PR introduces a documentation/specification change that clarifies how identifiers (names and keys) are compared. The decisions are recorded in ADR-12, included in this PR.