### PR TITLE
Add `AggregateCommandScope.Exists()` and `ProcessEventScope.HasBegun()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- **[BC]** Add `AggregateCommandScope.Exists()`
+- **[BC]** Add `ProcessEventScope.HasBegun()` and `ProcessTimeoutScope.HasBegun()`
+
 ## [0.6.3] - 2020-01-14
 
 ### Changed

--- a/aggregate.go
+++ b/aggregate.go
@@ -156,6 +156,13 @@ type AggregateCommandScope interface {
 	// InstanceID returns the ID of the targeted aggregate instance.
 	InstanceID() string
 
+	// Exists returns true if the aggregate instance exists.
+	//
+	// It returns true if Create() has been called and Destroy() has not yet
+	// been called in this scope or the scope of any previous message that
+	// targetted the same instance.
+	Exists() bool
+
 	// Create creates the targeted instance.
 	//
 	// It MUST be called before Root() or RecordEvent() can be called within

--- a/process.go
+++ b/process.go
@@ -273,6 +273,13 @@ type ProcessTimeoutScope interface {
 	// InstanceID returns the ID of the targeted process instance.
 	InstanceID() string
 
+	// HasBegun returns true if the process has begun.
+	//
+	// It returns true if Begin() has been called and End() has not yet been
+	// called in this scope or the scope of any previous message that targetted
+	// the same instance.
+	HasBegun() bool
+
 	// End terminates the targeted process instance.
 	//
 	// After it has been called Root(), ExecuteCommand() and ScheduleTimeout()

--- a/process.go
+++ b/process.go
@@ -204,6 +204,13 @@ type ProcessEventScope interface {
 	// InstanceID returns the ID of the targeted process instance.
 	InstanceID() string
 
+	// HasBegun returns true if the process has begun.
+	//
+	// It returns true if Begin() has been called and End() has not yet been
+	// called in this scope or the scope of any previous message that targetted
+	// the same instance.
+	HasBegun() bool
+
 	// Begin starts the targeted process instance.
 	//
 	// It MUST be called before Root(), ExecuteCommand() or ScheduleTimeout()


### PR DESCRIPTION
Fixes #119 

Assuming we roll with the `Exists()` approach in #119, this PR contains the relevant Dogma interface changes.