### PR TITLE
Recommend returning the same value/type from each call to `New()`.

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -18,9 +18,11 @@ package dogma
 // A command message can cause the creation or destruction of its target
 // instance.
 type AggregateMessageHandler interface {
-	// New constructs a new aggregate instance and returns its root.
+	// New constructs constructs new aggregate instance initialized with any
+	// default values and returns the aggregate root.
 	//
-	// The return value MUST NOT be nil.
+	// Repeated calls SHOULD return a value that is of the same type and
+	// initialized in the same way. The return value MUST NOT be nil.
 	New() AggregateRoot
 
 	// Configure produces a configuration for this handler by calling methods on

--- a/aggregate.go
+++ b/aggregate.go
@@ -18,7 +18,7 @@ package dogma
 // A command message can cause the creation or destruction of its target
 // instance.
 type AggregateMessageHandler interface {
-	// New constructs constructs new aggregate instance initialized with any
+	// New constructs a new aggregate instance initialized with any
 	// default values and returns the aggregate root.
 	//
 	// Repeated calls SHOULD return a value that is of the same type and

--- a/process.go
+++ b/process.go
@@ -27,9 +27,12 @@ import (
 // updating a database or invoking an API operation that causes a state change.
 // Any such state changes should be communicated via a command message instead.
 type ProcessMessageHandler interface {
-	// New constructs a new process instance and returns its root.
+	// New constructs constructs new process instance initialized with any
+	// default values and returns the process root.
 	//
-	// The return value MUST NOT be nil.
+	// Repeated calls SHOULD return a value that is of the same type and
+	// initialized in the same way. The return value MUST NOT be nil.
+	// New constructs a new process instance and returns its root.
 	New() ProcessRoot
 
 	// Configure produces a configuration for this handler by calling methods on

--- a/process.go
+++ b/process.go
@@ -27,12 +27,11 @@ import (
 // updating a database or invoking an API operation that causes a state change.
 // Any such state changes should be communicated via a command message instead.
 type ProcessMessageHandler interface {
-	// New constructs constructs new process instance initialized with any
+	// New constructs a new process instance initialized with any
 	// default values and returns the process root.
 	//
 	// Repeated calls SHOULD return a value that is of the same type and
 	// initialized in the same way. The return value MUST NOT be nil.
-	// New constructs a new process instance and returns its root.
 	New() ProcessRoot
 
 	// Configure produces a configuration for this handler by calling methods on


### PR DESCRIPTION
Fixes #79 

I didn't want to overspecify this, as it's likely we will need to allow for an aggregate to change the type used to represent it over time. For now I've simply recommended that the same type is always returned on repeat calls to `New()`.