### PR TITLE
Make panicking with `UnexpectedMessage` optional.

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -43,8 +43,8 @@ type AggregateMessageHandler interface {
 	//
 	// The engine MUST NOT call RouteCommandToInstance() with any message of a
 	// type that has not been configured for consumption by a prior call to
-	// Configure(). If any such message is passed, the implementation MUST panic
-	// with the UnexpectedMessage value.
+	// Configure(). If any such message is passed, the implementation SHOULD
+	// panic with the UnexpectedMessage value.
 	RouteCommandToInstance(m Message) string
 
 	// HandleCommand handles a command message.
@@ -63,13 +63,14 @@ type AggregateMessageHandler interface {
 	//
 	// The engine MUST NOT call HandleCommand() with any message of a type that
 	// has not been configured for consumption by a prior call to Configure().
-	// If any such message is passed, the implementation MUST panic with the
+	// If any such message is passed, the implementation SHOULD panic with the
 	// UnexpectedMessage value.
 	//
 	// The implementation MUST NOT assume that HandleCommand() will be called
 	// with commands in the same order that they were executed.
 	//
-	// The engine MAY call HandleCommand() from multiple goroutines concurrently.
+	// The engine MAY call HandleCommand() from multiple goroutines
+	// concurrently.
 	HandleCommand(s AggregateCommandScope, m Message)
 }
 
@@ -87,8 +88,8 @@ type AggregateRoot interface {
 	// The implementation MUST accept the event types as described above, though
 	// any such call MAY be a no-op.
 	//
-	// The implementation MUST panic with the UnexpectedMessage value if called
-	// with any event type other than those described above.
+	// The implementation SHOULD panic with the UnexpectedMessage value if
+	// called with any event type other than those described above.
 	ApplyEvent(m Message)
 }
 

--- a/integration.go
+++ b/integration.go
@@ -35,13 +35,14 @@ type IntegrationMessageHandler interface {
 	//
 	// The engine MUST NOT call HandleCommand() with any message of a type that
 	// has not been configured for consumption by a prior call to Configure().
-	// If any such message is passed, the implementation MUST panic with the
+	// If any such message is passed, the implementation SHOULD panic with the
 	// UnexpectedMessage value.
 	//
 	// The implementation MUST NOT assume that HandleCommand() will be called
 	// with commands in the same order that they were executed.
 	//
-	// The engine MAY call HandleCommand() from multiple goroutines concurrently.
+	// The engine MAY call HandleCommand() from multiple goroutines
+	// concurrently.
 	HandleCommand(ctx context.Context, s IntegrationCommandScope, m Message) error
 
 	// TimeoutHint returns a duration that is suitable for computing a deadline

--- a/process.go
+++ b/process.go
@@ -54,8 +54,8 @@ type ProcessMessageHandler interface {
 	//
 	// The engine MUST NOT call RouteEventToInstance() with any message of a
 	// type that has not been configured for consumption by a prior call to
-	// Configure(). If any such message is passed, the implementation MUST panic
-	// with the UnexpectedMessage value.
+	// Configure(). If any such message is passed, the implementation SHOULD
+	// panic with the UnexpectedMessage value.
 	RouteEventToInstance(ctx context.Context, m Message) (id string, ok bool, err error)
 
 	// HandleEvent handles an event message.
@@ -74,7 +74,7 @@ type ProcessMessageHandler interface {
 	//
 	// The engine MUST NOT call HandleEvent() with any message of a type that
 	// has not been configured for consumption by a prior call to Configure().
-	// If any such message is passed, the implementation MUST panic with the
+	// If any such message is passed, the implementation SHOULD panic with the
 	// UnexpectedMessage value.
 	//
 	// The engine MAY provide guarantees about the order in which event messages
@@ -98,7 +98,7 @@ type ProcessMessageHandler interface {
 	//
 	// The engine MUST NOT call HandleTimeout() with any message that was not
 	// scheduled by this handler. If any such message is passed, the
-	// implementation MUST panic with the UnexpectedMessage value.
+	// implementation SHOULD panic with the UnexpectedMessage value.
 	//
 	// The engine SHOULD provide "at-least-once" delivery guarantees to the
 	// handler. That is, the engine should call HandleTimeout() with the same

--- a/projection.go
+++ b/projection.go
@@ -75,7 +75,7 @@ type ProjectionMessageHandler interface {
 	//
 	// The engine MUST NOT call HandleEvent() with any message of a type that
 	// has not been configured for consumption by a prior call to Configure().
-	// If any such message is passed, the implementation MUST panic with the
+	// If any such message is passed, the implementation SHOULD panic with the
 	// UnexpectedMessage value.
 	//
 	// The engine MAY call HandleEvent() from multiple goroutines concurrently.


### PR DESCRIPTION
We've found that making this a hard requirement can lead to noisy or unnecessarily complex handler implementations in real domains.

Relaxing this requirement from a `MUST` to a `SHOULD` absolves the handler implementor from the responsibility of checking that the message type is valid when some other logic has already determined that the message can be ignored.