### PR TITLE
Reinstate panic requirement on routing methods.

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -43,7 +43,7 @@ type AggregateMessageHandler interface {
 	//
 	// The engine MUST NOT call RouteCommandToInstance() with any message of a
 	// type that has not been configured for consumption by a prior call to
-	// Configure(). If any such message is passed, the implementation SHOULD
+	// Configure(). If any such message is passed, the implementation MUST
 	// panic with the UnexpectedMessage value.
 	RouteCommandToInstance(m Message) string
 

--- a/docs/adr/0014-apply-historical-events-to-aggregates.md
+++ b/docs/adr/0014-apply-historical-events-to-aggregates.md
@@ -6,6 +6,8 @@ Date: 2020-10-19
 
 Accepted
 
+- Amended By [15. Routing Unrecognized Messages](0015-routing-unrecognized-messages.md)
+
 ## Context
 
 Event sourcing engines need to call `AggregateRoot.ApplyEvent()` with

--- a/docs/adr/0015-routing-unrecognized-messages.md
+++ b/docs/adr/0015-routing-unrecognized-messages.md
@@ -1,0 +1,32 @@
+# 15. Routing Unrecognized Messages
+
+Date: 2020-11-01
+
+## Status
+
+Accepted
+
+- Amends [14. Applying Historical Events to Aggregate Instances](0014-apply-historical-events-to-aggregates.md)
+
+## Context
+
+ADR-14 relaxed the specification such that handler implementations were no
+longer required to panic with an `UnrecognizedMessage` value when passed an
+unexpected message type. However, it probably did so too broadly.
+
+Specifically, unlike when handling a message, the routing methods
+`AggregateMessageHandler.RouteCommandToInstance()` and
+`ProcessMessageHandler.RouteEventToInstance()` do not have the option of "doing
+nothing" when passed an unexpected message type.
+
+## Decision
+
+Reinstate the hard requirement that the handlers MUST panic with
+`UnexpectedMessage` when asked to route a message type that was not configured
+as being produced by that handler.
+
+## Consequences
+
+This reduces ambiguity about how the handler should be implemented, and allows
+tools like "testkit" and "dogmavet" to make stricter assertions and more direct
+suggestions.

--- a/docs/adr/0015-routing-unrecognized-messages.md
+++ b/docs/adr/0015-routing-unrecognized-messages.md
@@ -23,7 +23,7 @@ nothing" when passed an unexpected message type.
 
 Reinstate the hard requirement that the handlers MUST panic with
 `UnexpectedMessage` when asked to route a message type that was not configured
-as being produced by that handler.
+as being consumed by that handler.
 
 ## Consequences
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,3 +24,4 @@ the ADR documents.
 * [12. Comparison of Identifiers](0012-identifier-comparison.md)
 * [13. Aggregate and Process Instance Existance Checks](0013-instance-exists-check.md)
 * [14. Applying Historical Events to Aggregate Instances](0014-apply-historical-events-to-aggregates.md)
+* [15. Routing Unrecognized Messages](0015-routing-unrecognized-messages.md)

--- a/process.go
+++ b/process.go
@@ -54,7 +54,7 @@ type ProcessMessageHandler interface {
 	//
 	// The engine MUST NOT call RouteEventToInstance() with any message of a
 	// type that has not been configured for consumption by a prior call to
-	// Configure(). If any such message is passed, the implementation SHOULD
+	// Configure(). If any such message is passed, the implementation MUST
 	// panic with the UnexpectedMessage value.
 	RouteEventToInstance(ctx context.Context, m Message) (id string, ok bool, err error)
 


### PR DESCRIPTION
This PR partially reverses the relaxations made in https://github.com/dogmatiq/dogma/pull/126, requiring the "routing" methods to panic using `UnexpectedMessage`.