### PR TITLE
Fix the context section of ADR-15 to explain its relationship to ADR-14 more correctly.

### DIFF
--- a/docs/adr/0014-apply-historical-events-to-aggregates.md
+++ b/docs/adr/0014-apply-historical-events-to-aggregates.md
@@ -6,8 +6,6 @@ Date: 2020-10-19
 
 Accepted
 
-- Amended By [15. Routing Unrecognized Messages](0015-routing-unrecognized-messages.md)
-
 ## Context
 
 Event sourcing engines need to call `AggregateRoot.ApplyEvent()` with

--- a/docs/adr/0015-routing-unrecognized-messages.md
+++ b/docs/adr/0015-routing-unrecognized-messages.md
@@ -6,13 +6,15 @@ Date: 2020-11-01
 
 Accepted
 
-- Amends [14. Applying Historical Events to Aggregate Instances](0014-apply-historical-events-to-aggregates.md)
-
 ## Context
 
-ADR-14 relaxed the specification such that handler implementations were no
+[ADR-14](0014-apply-historical-events-to-aggregates.md) relaxed the
+specification such that `AggregateRoot.ApplyEvent()` implementations were no
 longer required to panic with an `UnrecognizedMessage` value when passed an
-unexpected message type. However, it probably did so too broadly.
+unexpected message type.
+
+Prompted by this requirement, we relaxed the requirement for ALL handler
+methods, which was likely too broad of a change.
 
 Specifically, unlike when handling a message, the routing methods
 `AggregateMessageHandler.RouteCommandToInstance()` and


### PR DESCRIPTION
Previously, ADR-15 incorrectly explained that it reversed part of ADR-14, however ADR-14 never mentioned the changes that were reversed.

This PR updates the description of ADR-15 to correct this misinformation. It does not change the decision made within ADR-15, which is why I did not create a new ADR.

