### PR TITLE
Allow calling `RecordEvent()` and `Destroy()` in any order.

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -174,17 +174,17 @@ type AggregateCommandScope interface {
 	// applied changes are visible to the handler.
 	RecordEvent(m Message)
 
-	// Destroy "forgets" the state of the targetted aggregate instance.
+	// Destroy indicates to the engine that the state of the aggregate root for
+	// the targetted instance is no longer meaningful.
 	//
-	// Root() will return a newly initialized aggregate instance for the next
-	// command message that targets this instance.
+	// A call to Destroy() is negated by a subsequent call to RecordEvent()
+	// within the same scope.
 	//
-	// RecordEvent() MUST be called at least once within the same scope. This
-	// guarantees that the destruction of every instance is represented by an
-	// application-defined event.
+	// Within scopes of future command messages that target this instance,
+	// Root() returns a newly initialized aggregate instance.
 	//
-	// The precise semantics of destroy are implementation defined. The
-	// aggregate data MAY be deleted or archived, for example.
+	// The precise semantics are implementation defined. The aggregate data MAY
+	// be deleted or archived, for example.
 	Destroy()
 
 	// Log records an informational message within the context of the message

--- a/docs/adr/0003-aggregate-lifetime-control.md
+++ b/docs/adr/0003-aggregate-lifetime-control.md
@@ -7,6 +7,7 @@ Date: 2018-12-10
 Approved
 
 - Amended by [16. Automatic Aggregate Creation](0016-automatic-aggregate-creation.md)
+- Amended by [17. Recreation of Aggregate Instances After Destruction](0017-recreate-aggregate-after-destruction.md)
 
 ## Context
 

--- a/docs/adr/0017-recreate-aggregate-after-destruction.md
+++ b/docs/adr/0017-recreate-aggregate-after-destruction.md
@@ -34,7 +34,7 @@ Calling `RecordEvent()` *after* `Destroy()` event should "negate" the call to
 The complex interplay between `RecordEvent()` and `Destroy()` is removed,
 allowing each to be understood and used in isolation.
 
-Changes to existing ingine implementations should be minimal, as they already
+Changes to existing engine implementations should be minimal, as they already
 handle destruction by setting an in-memory flag that is checked after
 `HandleCommand()` is invoked. Likely they can be changed to simply unset that
 flag in `RecordEvent()`.

--- a/docs/adr/0017-recreate-aggregate-after-destruction.md
+++ b/docs/adr/0017-recreate-aggregate-after-destruction.md
@@ -1,0 +1,46 @@
+# 17. Recreation of Aggregate Instances After Destruction
+
+Date: 2020-11-05
+
+## Status
+
+Accepted
+
+- Amends [3. Aggregate Lifetime Control](0003-aggregate-lifetime-control.md)
+
+## Context
+
+After implementing several real business domains we have found that it can be
+difficult to use `AggregateCommandScope.Destroy()` effectively.
+
+Ideally, `Destroy()` could be called after recording any event that effectively
+"resets" the aggregate's state, from the perspective of the business logic.
+
+In practice, logic that results in a call to `Destroy()` may be followed by some
+conditional logic that records a new event. In existing implementations this
+results in a panic from the engine, though as of ADR-16, which removed
+`Create()` this is no longer documented as required engine behavior.
+
+## Decision
+
+Remove the requirement that any call to `Destroy()` be preceeded by a call to
+`RecordEvent()` within the same scope.
+
+Calling `RecordEvent()` *after* `Destroy()` event should "negate" the call to
+`Destroy()`, as though it were never called.
+
+## Consequences
+
+The complex interplay between `RecordEvent()` and `Destroy()` is removed,
+allowing each to be understood and used in isolation.
+
+Changes to existing ingine implementations should be minimal, as they already
+handle destruction by setting an in-memory flag that is checked after
+`HandleCommand()` is invoked. Likely they can be changed to simply unset that
+flag in `RecordEvent()`.
+
+There is one subtle behavior that results from these changes, which is that
+after calling `Destroy()` the `AggregateRoot` returned by
+`AggregateCommandScope.Root()` is not "reset", as there is no mechanism to do
+so. This potentially differs to how the root will appear when the next command
+is received, when it will be equal to `AggregateMessageHandler.New()`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,3 +26,4 @@ the ADR documents.
 * [14. Applying Historical Events to Aggregate Instances](0014-apply-historical-events-to-aggregates.md)
 * [15. Routing Unrecognized Messages](0015-routing-unrecognized-messages.md)
 * [16. Automatic Aggregate Creation](0016-automatic-aggregate-creation.md)
+* [17. Recreation of Aggregate Instances After Destruction](0017-recreate-aggregate-after-destruction.md)


### PR DESCRIPTION
Fixes #132

This PR removes the call-order relationship between `RecordEvent()` and `Destroy()` such that they can be called in any order.

- `Destroy()` no longer requires `RecordEvent()` to be called beforehand
- Calling `RecordEvent()` after `Destroy()` essentially "un-does" the `Destroy()`, as though it were never called