### PR TITLE
Pass aggregate root directly to `AggregateMessageHandler.HandleCommand()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,14 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Changed
 
+- **[BC]** `AggregateMessageHandler.HandleCommand()` now takes an `AggregateRoot` parameter
 - **[BC]** `fixtures.AggregateRoot` now stores all its historical events internally
 - `AggregateCommandScope.Destroy()` no longer requires a prior call to `RecordEvent()`
 - `AggregateCommandScope.RecordEvent()` can now be called after `Destroy()`
+
+### Removed
+
+- **[BC]** Remove `AggregateCommandScope.Root()`
 
 ## [0.8.0] - 2020-11-03
 

--- a/fixtures/aggregate.go
+++ b/fixtures/aggregate.go
@@ -30,7 +30,7 @@ type AggregateMessageHandler struct {
 	NewFunc                    func() dogma.AggregateRoot
 	ConfigureFunc              func(dogma.AggregateConfigurer)
 	RouteCommandToInstanceFunc func(dogma.Message) string
-	HandleCommandFunc          func(dogma.AggregateCommandScope, dogma.Message)
+	HandleCommandFunc          func(dogma.AggregateRoot, dogma.AggregateCommandScope, dogma.Message)
 }
 
 var _ dogma.AggregateMessageHandler = &AggregateMessageHandler{}
@@ -73,9 +73,13 @@ func (h *AggregateMessageHandler) RouteCommandToInstance(m dogma.Message) string
 // HandleCommand handles a domain command message that has been routed to this
 // handler.
 //
-// If h.HandleCommandFunc is non-nil it calls h.HandleCommandFunc(s, m).
-func (h *AggregateMessageHandler) HandleCommand(s dogma.AggregateCommandScope, m dogma.Message) {
+// If h.HandleCommandFunc is non-nil it calls h.HandleCommandFunc(r, s, m).
+func (h *AggregateMessageHandler) HandleCommand(
+	r dogma.AggregateRoot,
+	s dogma.AggregateCommandScope,
+	m dogma.Message,
+) {
 	if h.HandleCommandFunc != nil {
-		h.HandleCommandFunc(s, m)
+		h.HandleCommandFunc(r, s, m)
 	}
 }


### PR DESCRIPTION
Fixes #133 

This PR removes `AggregateCommandScope.Root()` and instead requires the engine to pass the root directly to `HandleCommand()`.