### PR TITLE
Add `ProjectionMessageHandler.Compact()` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
+- **[BC]** Add `ProjectionMessageHandler.Compact()` and `NoCompactBehavior`
 - Add `ValidatableMessage` interface and `ValidateMessage()`
 
 ## [0.9.0] - 2020-11-06

--- a/docs/adr/0018-projection-compaction.md
+++ b/docs/adr/0018-projection-compaction.md
@@ -1,0 +1,80 @@
+# 18. Compacting Projection Data
+
+Date: 2020-11-11
+
+## Status
+
+Accepted
+
+## Context
+
+Many projections produce data that is only required for a limited period of
+time.
+
+An application developer needs to consider how long projection data will be
+retained and ideally implement measures to remove any unecessary data.
+
+Often such data can be removed when some future event occurs. However, in some
+cases there is no future event that appropriately indicates the data is no
+longer required.
+
+We have encountered a genuine example of this when implementing an SQL
+projection that inserts a row whenever a user performs a specific action. The
+data is queried in order to enforce a "cool down" that prevents the user from
+repeating that action again within a specific time frame.
+
+The insert is triggered by the occurrence of an event, but the data becomes
+unnecessary whenever the "cool down" time has elapsed.
+
+In this particular use case the "cool down" was not part of the business logic,
+but rather an API level restriction. Hence, processes/timeout messages were not
+the appropriate solution.
+
+## Decision
+
+We have decided to add a `Compact()` method to `ProjectionMessageHandler`.
+
+The implementation of `Compact()` can modify the projection's data by whatever
+means is appropriate such that unnecessary data is removed but the projection
+still serves its purpose.
+
+## Consequences
+
+### Engine Complexity
+
+This change does introduce further complexity to engine implementations. It is,
+of course, entirely possible to perform this kind of compaction outside the
+engine. To keep this compexity to a minimum we have avoided building in any
+facility for the projection handler to schedule compaction at specific times.
+
+### Backwards Compatibility
+
+Every existing projection implementation now requires an addtional method, even
+if no compaction is required. The `NoCompactBehavior` struct can be embedded
+within a `ProjectionMessageHandler` implementation to provide a no-op
+implementation of `Compact()`.
+
+### First Class Compaction
+
+Making compaction a first-class feature of the projection interface encourages
+application developers to think about the lifetime of the projection's data and
+how it might be cleaned up; something that might easily be ignored.
+
+### Testing
+
+`dogmatiq/testkit` can be updated to perform compaction when events are routed
+to projections, ensuring that the compaction code is actually invoked during
+testing and hopefully that it does not interfere with the regular operation of
+the projection.
+
+### Optimal Scheduling of Compaction
+
+Many aspects of an engine's behavior are engine-specific. By giving the engine
+control over when compaction occurs engine implemenators may be able to make
+informed decisions about when it's appropriate to perform compaction.
+
+For example, an engine may perform compaction only when there is a period of low
+event activity.
+
+Engine implementations that use clustering and/or sharding techniques might
+schedule compaction to occur on a single node.

--- a/docs/adr/0018-projection-compaction.md
+++ b/docs/adr/0018-projection-compaction.md
@@ -12,7 +12,7 @@ Many projections produce data that is only required for a limited period of
 time.
 
 An application developer needs to consider how long projection data will be
-retained and ideally implement measures to remove any unecessary data.
+retained and ideally implement measures to remove any unnecessary data.
 
 Often such data can be removed when some future event occurs. However, in some
 cases there is no future event that appropriately indicates the data is no

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,3 +27,4 @@ the ADR documents.
 * [15. Routing Unrecognized Messages](0015-routing-unrecognized-messages.md)
 * [16. Automatic Aggregate Creation](0016-automatic-aggregate-creation.md)
 * [17. Recreation of Aggregate Instances After Destruction](0017-recreate-aggregate-after-destruction.md)
+* [18. Compacting Projection Data](0018-projection-compaction.md)

--- a/fixtures/projection.go
+++ b/fixtures/projection.go
@@ -14,7 +14,8 @@ type ProjectionMessageHandler struct {
 	HandleEventFunc     func(context.Context, []byte, []byte, []byte, dogma.ProjectionEventScope, dogma.Message) (bool, error)
 	ResourceVersionFunc func(context.Context, []byte) ([]byte, error)
 	CloseResourceFunc   func(context.Context, []byte) error
-	TimeoutHintFunc     func(m dogma.Message) time.Duration
+	TimeoutHintFunc     func(dogma.Message) time.Duration
+	CompactFunc         func(context.Context, dogma.ProjectionCompactScope) error
 }
 
 var _ dogma.ProjectionMessageHandler = &ProjectionMessageHandler{}
@@ -83,4 +84,16 @@ func (h *ProjectionMessageHandler) TimeoutHint(m dogma.Message) time.Duration {
 	}
 
 	return 0
+}
+
+// Compact attempts to reduce the size of the projection's data.
+//
+// If h.CompactFunc is non-nil it returns h.CompactFunc(ctx, s), otherwise it
+// returns nil.
+func (h *ProjectionMessageHandler) Compact(ctx context.Context, s dogma.ProjectionCompactScope) error {
+	if h.CompactFunc != nil {
+		return h.CompactFunc(ctx, s)
+	}
+
+	return nil
 }

--- a/projection.go
+++ b/projection.go
@@ -121,14 +121,13 @@ type ProjectionMessageHandler interface {
 	// projection's data by whatever means available. For example, it may delete
 	// any unused data, or collapse multiple data sets into one.
 	//
+	// The context MAY have deadline. The implementation SHOULD attempt to
+	// compact data in discrete units, such that if the deadline is reached a
+	// future call to Compact() does not need to compact the same data.
+	//
 	// The engine SHOULD call Compact() repeatedly throughout the lifetime of
 	// the projection. The precise scheduling of calls to Compact() are
 	// engine-defined. It MAY be called concurrently with any other method.
-	//
-	// The engine MAY, of course, use a context deadline. The implementation
-	// SHOULD attempt to compact data in discrete units, such that if the
-	// deadline is reached a future call to Compact() does not need to compact
-	// the same data.
 	Compact(ctx context.Context, s ProjectionCompactScope) error
 }
 

--- a/projection.go
+++ b/projection.go
@@ -121,7 +121,7 @@ type ProjectionMessageHandler interface {
 	// projection's data by whatever means available. For example, it may delete
 	// any unused data, or collapse multiple data sets into one.
 	//
-	// The context MAY have deadline. The implementation SHOULD attempt to
+	// The context MAY have a deadline. The implementation SHOULD attempt to
 	// compact data in discrete units, such that if the deadline is reached a
 	// future call to Compact() does not need to compact the same data.
 	//

--- a/projection_test.go
+++ b/projection_test.go
@@ -1,0 +1,18 @@
+package dogma_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/dogmatiq/dogma"
+)
+
+func TestNoCompactBehaviorBehavior_Compact_ReturnsNil(t *testing.T) {
+	var v NoCompactBehavior
+
+	err := v.Compact(context.Background(), nil)
+
+	if err != nil {
+		t.Fatal("unexpected error returned")
+	}
+}


### PR DESCRIPTION
This PR adds support for "projection compaction", which is an operation on projections that can be invoked by the engine to clean up any "unused" or "oversized" projection data.  

The wording is intentionally vague about what exactly this means as the implementations will differ depending on data store and the specific projection implementation. 

One hypothetical example that could apply to `dogmatiq/example` would be if we had a report showing the last 30 days of transaction history. The `Compact()` implementation might remove rows from an SQL table for transactions older than 30 days.

We decided to build this into the `ProjectionMessageHandler` interface (rather than just requiring the developer to launch their own cleanup goroutine) for several reasons:

- it encourages projection implementors to think about the lifetime of their data
- testkit can perform compaction, perhaps with some randomness, to ensure compaction does not interfere with regular projection behavior
- engines could potentially schedule compaction during periods of low activity on the projection
- clustered engines could ensure compaction only runs on a single node
