### PR TITLE
Add `ValidatableMessage`.

### DIFF
--- a/fixtures/message.go
+++ b/fixtures/message.go
@@ -1,5 +1,16 @@
 package fixtures
 
+import "errors"
+
+// InvalidMessage is a dogma.ValidatableMessage that is always considered
+// invalid.
+type InvalidMessage struct{}
+
+// Validate always returns an error.
+func (InvalidMessage) Validate() error {
+	return errors.New("<invalid>")
+}
+
 // MessageA is type used as a dogma.Message in tests.
 type MessageA struct {
 	Value interface{}

--- a/message.go
+++ b/message.go
@@ -66,7 +66,8 @@ func DescribeMessage(m Message) string {
 
 // ValidatableMessage is a message that can validate itself.
 //
-// This interface can be implemented to fine-grained validation of messages.
+// This interface can be implemented to perform fine-grained validation of
+// messages.
 //
 // Engine implementations SHOULD validate messages before allowing them to be
 // produced in order to prevent "poison" messages from entering the application.

--- a/message.go
+++ b/message.go
@@ -1,6 +1,9 @@
 package dogma
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // A Message is an application-defined unit of data that encapsulates a
 // "command" or "event" within a message-based application.
@@ -17,6 +20,9 @@ import "fmt"
 //
 // Message implementations SHOULD implement fmt.Stringer or DescribableMessage
 // in order to provide a human-readable description of every message.
+//
+// Message implementations SHOULD implement ValidatableMessage in order to
+// allow the engine to validate messages before they enter the application.
 //
 // Engine implementations MAY place further requirements upon message
 // implementations.
@@ -55,6 +61,34 @@ func DescribeMessage(m Message) string {
 		return m.String()
 	default:
 		return fmt.Sprintf("%v", m)
+	}
+}
+
+// ValidatableMessage is a message that can validate itself.
+//
+// This interface can be implemented to fine-grained validation of messages.
+//
+// Engine implementations SHOULD validate messages before allowing them to be
+// produced in order to prevent "poison" messages from entering the application.
+type ValidatableMessage interface {
+	Message
+
+	// Validate returns a non-nil error if the message is invalid.
+	Validate() error
+}
+
+// ValidateMessage returns an error if m implements ValidatableMessage and is
+// invalid.
+//
+// If m does not implement ValidatableMessage it returns nil.
+func ValidateMessage(m Message) error {
+	switch m := m.(type) {
+	case ValidatableMessage:
+		return m.Validate()
+	case nil:
+		return errors.New("message must not be nil")
+	default:
+		return nil
 	}
 }
 

--- a/message_test.go
+++ b/message_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/dogma/fixtures"
 )
 
 type describable struct{}
@@ -44,5 +45,34 @@ func TestDescribeMessage_default(t *testing.T) {
 	d := DescribeMessage(indescribable{100})
 	if d != "{100}" {
 		t.Fatal("unexpected message description")
+	}
+}
+
+func TestValidateMessage_validatable(t *testing.T) {
+	err := ValidateMessage(fixtures.InvalidMessage{})
+	if err == nil {
+		t.Fatal("expected an error to occur")
+	}
+
+	if err.Error() != "<invalid>" {
+		t.Fatalf("unexpected error message: %s", err.Error())
+	}
+}
+
+func TestValidateMessage_nil(t *testing.T) {
+	err := ValidateMessage(nil)
+	if err == nil {
+		t.Fatal("expected an error to occur")
+	}
+
+	if err.Error() != "message must not be nil" {
+		t.Fatalf("unexpected error message: %s", err.Error())
+	}
+}
+
+func TestValidateMessage_default(t *testing.T) {
+	err := ValidateMessage(struct{}{})
+	if err != nil {
+		t.Fatal("unexpected error")
 	}
 }


### PR DESCRIPTION
This PR adds the `ValidatableMessage` interface with the single message `Validate()`.

Engine implementations, including testkit, can use this method, if implemented, to confirm that the message is valid before allowing it to be produced.