### PR TITLE
Add `Now()` method to `ProjectionCompactScope`.

### DIFF
--- a/projection.go
+++ b/projection.go
@@ -201,6 +201,17 @@ type ProjectionCompactScope interface {
 	// Log records an informational message within the context of the message
 	// that is being handled.
 	Log(f string, v ...interface{})
+
+	// Now returns the current engine time.
+	//
+	// The handler SHOULD use the returned time to implement compaction logic
+	// that has some time-based component, such as removing data that is older
+	// than a certain age.
+	//
+	// Under normal operating conditions the engine SHOULD return the current
+	// local time, equivalent to time.Now(). The engine MAY return a different
+	// time under special circumstances, such as when executing tests.
+	Now() time.Time
 }
 
 // NoCompactBehavior can be embedded in ProjectionMessageHandler implementations


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR introduces a `Now()` method to the `ProjectionCompactScope` interface.

#### Why make this change?

This allows compaction logic to expire old data even under testkit and/or its memory engine where the engine's notion of time is not necessarily the real wall clock time.

#### Is there anything you are unsure about?

We are unsure if this method may be needed on other scopes as well, but have opted only to implement it here for now as we have a concrete use case for compacting projections.

#### What issues does this relate to?

Fixes #141
