### PR TITLE
Use the codecov GitHub action instead of the bash uploader.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,4 @@ jobs:
     - name: Make
       run: make ci
     - name: Upload Coverage Reports
-      if: success()
-      run: |
-        [[ -z "${{ secrets.CODECOV_TOKEN }}" ]] || bash <(curl -s https://codecov.io/bash) -t "${{ secrets.CODECOV_TOKEN }}" -B "${{ github.ref }}"
+      uses: codecov/codecov-action@v2


### PR DESCRIPTION
The bash uploader is deprecated and will begin experiencing forced brownouts.