### PR TITLE
Add Disable() method to configurers.

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -94,6 +94,17 @@ type AggregateConfigurer interface {
 	// Aggregate handlers support the HandlesCommand() and RecordsEvent() route
 	// types.
 	Routes(...AggregateRoute)
+
+	// Disable prevents the handler from receiving any messages.
+	//
+	// The engine MUST NOT call any methods other than Configure() on a disabled
+	// handler.
+	//
+	// Disabling a handler is useful when the handler's configuration prevents
+	// it from operating, such as when it's missing a required dependency,
+	// without requiring the user to conditionally register the handler with the
+	// application.
+	Disable(...DisableOption)
 }
 
 // AggregateCommandScope performs engine operations within the context of a call

--- a/disable.go
+++ b/disable.go
@@ -1,0 +1,4 @@
+package dogma
+
+// DisableOption is an option that affects the behavior of a disabled handler.
+type DisableOption struct{}

--- a/docs/vale/config/vocabularies/Technical/accept.txt
+++ b/docs/vale/config/vocabularies/Technical/accept.txt
@@ -1,3 +1,4 @@
+[Dd]eduplication
 [Dd]estroy
 [Dd]isable
 [Dd]isabled
@@ -19,5 +20,4 @@
 [Oo]nly
 [Vv]alidate
 [Ww]hitespace
-deduplication
 ADR|adr

--- a/integration.go
+++ b/integration.go
@@ -56,6 +56,17 @@ type IntegrationConfigurer interface {
 	// Integration handlers support the HandlesCommand() and RecordsEvent()
 	// route types.
 	Routes(...IntegrationRoute)
+
+	// Disable prevents the handler from receiving any messages.
+	//
+	// The engine MUST NOT call any methods other than Configure() on a disabled
+	// handler.
+	//
+	// Disabling a handler is useful when the handler's configuration prevents
+	// it from operating, such as when it's missing a required dependency,
+	// without requiring the user to conditionally register the handler with the
+	// application.
+	Disable(...DisableOption)
 }
 
 // IntegrationCommandScope performs engine operations within the context of a

--- a/process.go
+++ b/process.go
@@ -119,6 +119,17 @@ type ProcessConfigurer interface {
 	// Process handlers support the HandlesEvent(), ExecutesCommand() and
 	// SchedulesTimeout() route types.
 	Routes(...ProcessRoute)
+
+	// Disable prevents the handler from receiving any messages.
+	//
+	// The engine MUST NOT call any methods other than Configure() on a disabled
+	// handler.
+	//
+	// Disabling a handler is useful when the handler's configuration prevents
+	// it from operating, such as when it's missing a required dependency,
+	// without requiring the user to conditionally register the handler with the
+	// application.
+	Disable(...DisableOption)
 }
 
 // ProcessEventScope performs engine operations within the context of a call

--- a/projection.go
+++ b/projection.go
@@ -114,6 +114,17 @@ type ProjectionConfigurer interface {
 	//
 	// The default policy is UnicastProjectionDeliveryPolicy.
 	DeliveryPolicy(ProjectionDeliveryPolicy)
+
+	// Disable prevents the handler from receiving any messages.
+	//
+	// The engine MUST NOT call any methods other than Configure() on a disabled
+	// handler.
+	//
+	// Disabling a handler is useful when the handler's configuration prevents
+	// it from operating, such as when it's missing a required dependency,
+	// without requiring the user to conditionally register the handler with the
+	// application.
+	Disable(...DisableOption)
 }
 
 // ProjectionEventScope performs engine operations within the context of a call


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/blob/main/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR introduces an `Disable()` method to each of the handler configured interfaces.

#### Why make this change?

It is often necessary to disable specific handlers by adding conditional logic to the application's `Configure()` method. For example, during tests we will often skip registering a projection handler if there is no SQL database available for testing.

This change allows the handler itself to decide if it should be disabled, rather than the application.

#### Is there anything you are unsure about?

I've added an as-yet-unused `DisableOption` in the interest for forward-compatibility. I'm hypothesising options such as a `DisableIf(predicate func() bool)`, which could act as a circuit breaker that stops an engine from routing messages to a handler while some dependency is unavailable.

#### What issues does this relate to?

None
