### PR TITLE
Validation scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ The format is based on [Keep a Changelog], and this project adheres to
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Removed
+
+- **[BC]** Removed `Message.Validate()` method.
+
+### Changed
+
+- **[BC]** Changed `Validate()` method on `Command`, `Event` and `Timeout` to
+  accept `CommandValidationScope`, `EventValidationScope` and
+  `TimeoutValidationScope`, respectively. This method was previously "inherited"
+  from the `Message` interface.
+
+### Added
+
+- Added `CommandValidationScope`, `EventValidationScope` and
+  `TimeoutValidationScope` interfaces.
+
+### Deprecated
+
+- The `Message` interface is no longer deprecated. It can still be useful within
+  engine implementations. Applications should continue to use the more-specific
+  `Command`, `Event` and `Timeout` interfaces wherever possible, which no longer
+  share compatible method sets.
+
 ## [0.14.3] - 2024-09-27
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Removed
 
-- **[BC]** Removed `Message.Validate()` method.
+- **[BC]** Removed `Message.Validate()`.
 
 ### Changed
 
-- **[BC]** Changed `Validate()` method on `Command`, `Event` and `Timeout` to
-  accept `CommandValidationScope`, `EventValidationScope` and
-  `TimeoutValidationScope`, respectively. This method was previously "inherited"
-  from the `Message` interface.
+- **[BC]** The `Validate()` methods on the `Command`, `Event` and `Timeout`
+  interfaces now require a `CommandValidationScope`, `EventValidationScope` and
+  `TimeoutValidationScope`, respectively.
 
 ### Added
 
@@ -30,10 +29,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Deprecated
 
-- The `Message` interface is no longer deprecated. It can still be useful within
-  engine implementations. Applications should continue to use the more-specific
-  `Command`, `Event` and `Timeout` interfaces wherever possible, which no longer
-  share compatible method sets.
+- The `Message` interface is **no longer deprecated** as it sees widespread use
+  within engine implementations. Applications should continue to use the
+  more-specific `Command`, `Event` and `Timeout` interfaces wherever possible,
+  which no longer share compatible method sets.
 
 ## [0.14.3] - 2024-09-27
 

--- a/message.go
+++ b/message.go
@@ -46,17 +46,17 @@ type unexpectedMessage struct{}
 // CommandValidationScope provides information about the context in which a
 // [Command] is being validated.
 type CommandValidationScope interface {
-	future()
+	reservedCommandValidationScope()
 }
 
 // EventValidationScope provides information about the context in which an
 // [Event] is being validated.
 type EventValidationScope interface {
-	future()
+	reservedEventValidationScope()
 }
 
 // TimeoutValidationScope provides information about the context in which a
 // [Timeout] is being validated.
 type TimeoutValidationScope interface {
-	future()
+	reservedTimeoutValidationScope()
 }

--- a/message.go
+++ b/message.go
@@ -2,15 +2,9 @@ package dogma
 
 // A Message is an application-defined unit of data that describes a [Command],
 // [Event], or [Timeout] within a message-based application.
-//
-// Deprecated: Application developers should use [Command], [Event], or
-// [Timeout] instead.
 type Message interface {
 	// MessageDescription returns a human-readable description of the message.
 	MessageDescription() string
-
-	// Validate returns a non-nil error if the message is invalid.
-	Validate() error
 }
 
 // A Command is a message that represents a request for a Dogma application to
@@ -20,7 +14,7 @@ type Command interface {
 	MessageDescription() string
 
 	// Validate returns a non-nil error if the message is invalid.
-	Validate() error
+	Validate(CommandValidationScope) error
 }
 
 // An Event is a message that indicates that some action has occurred within a
@@ -30,7 +24,7 @@ type Event interface {
 	MessageDescription() string
 
 	// Validate returns a non-nil error if the message is invalid.
-	Validate() error
+	Validate(EventValidationScope) error
 }
 
 // A Timeout is a message that represents a request for an action to be
@@ -40,7 +34,7 @@ type Timeout interface {
 	MessageDescription() string
 
 	// Validate returns a non-nil error if the message is invalid.
-	Validate() error
+	Validate(TimeoutValidationScope) error
 }
 
 // UnexpectedMessage is a panic value used by a message handler when it receives
@@ -48,3 +42,21 @@ type Timeout interface {
 var UnexpectedMessage unexpectedMessage
 
 type unexpectedMessage struct{}
+
+// CommandValidationScope provides information about the context in which a
+// [Command] is being validated.
+type CommandValidationScope interface {
+	future()
+}
+
+// EventValidationScope provides information about the context in which an
+// [Event] is being validated.
+type EventValidationScope interface {
+	future()
+}
+
+// TimeoutValidationScope provides information about the context in which a
+// [Timeout] is being validated.
+type TimeoutValidationScope interface {
+	future()
+}


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/blob/main/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds "validation scopes" to the `Validate()` methods of `Command`, `Event` and `Timeout`.

#### Why make this change?

The intent is to allow the engine to supply useful information about the context in which the message is being validated. For example, it may be useful to know whether an event being validated is historical or being recorded "now".

This is part of a staged release. For the time being the new interfaces have no exported methods, but by adding them now we can prevent the need for app-facing BC breaks after a v1.0.0 release.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
