### PR TITLE
Add `ApplicationConfigurer.Handlers()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ The format is based on [Keep a Changelog], and this project adheres to
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+This releases introduces the `Handlers()` method to the `ApplicationConfigurer`
+interface. Implementors should use `Handlers()` in preference to the existing
+`Register*()` methods, which are now deprecated.
+
+The `Handlers()` offers a more extensible interface that allows future support
+for changes to handler configuration without introducing interface-level
+compilation errors.
+
+### Added
+
+- **[ENGINE BC]** Added `Handlers()` method to `ApplicationConfigurer`
+- Added `RegisterAggregate()`
+- Added `RegisterProcess()`
+- Added `RegisterIntegration()`
+- Added `RegisterProjection()`
+- Added `HandlerRegistration` interface
+- Added `AggregateRegistration` type
+- Added `ProcessRegistration` type
+- Added `IntegrationRegistration` type
+- Added `ProjectionRegistration` type
+
+### Deprecated
+
+- Deprecated `ApplicationConfigurer.RegisterAggregate()`
+- Deprecated `ApplicationConfigurer.RegisterProcess()`
+- Deprecated `ApplicationConfigurer.RegisterIntegration()`
+- Deprecated `ApplicationConfigurer.RegisterProjection()`
+
 ## [0.15.0] - 2024-10-03
 
 ### Removed

--- a/application.go
+++ b/application.go
@@ -23,21 +23,94 @@ type ApplicationConfigurer interface {
 	// Use of hard-coded literals for both values is RECOMMENDED.
 	Identity(n string, k string)
 
+	// Handlers configures the application to route messages to and from
+	// specific message handlers.
+	Handlers(...HandlerRegistration)
+
 	// RegisterAggregate configures the engine to route messages for an
 	// aggregate.
+	//
+	// Deprecated: Pass the result of [RegisterAggregate] to the Handlers()
+	// method instead.
 	RegisterAggregate(AggregateMessageHandler, ...RegisterAggregateOption)
 
 	// RegisterProcess configures the engine to route messages for a process.
+	//
+	// Deprecated: Pass the result of [RegisterProcess] to the Handlers()
+	// method instead.
 	RegisterProcess(ProcessMessageHandler, ...RegisterProcessOption)
 
 	// RegisterIntegration configures the engine to route messages for an
 	// integration.
+	//
+	// Deprecated: Pass the result of [RegisterIntegration] to the Handlers()
+	// method instead.
 	RegisterIntegration(IntegrationMessageHandler, ...RegisterIntegrationOption)
 
 	// RegisterProjection configures the engine to route messages for a
 	// projection.
+	//
+	// Deprecated: Pass the result of [RegisterProjection] to the Handlers()
+	// method instead.
 	RegisterProjection(ProjectionMessageHandler, ...RegisterProjectionOption)
 }
+
+// RegisterAggregate registers an [AggregateMessageHandler] with an
+// [Application].
+//
+// It is used as an argument to the Handlers() method of
+// [ApplicationConfigurer].
+func RegisterAggregate(h AggregateMessageHandler, _ ...RegisterAggregateOption) HandlerRegistration {
+	return AggregateRegistration{h}
+}
+
+// RegisterProcess registers a [ProcessMessageHandler] with an [Application].
+//
+// It is used as an argument to the Handlers() method of
+// [ApplicationConfigurer].
+func RegisterProcess(h ProcessMessageHandler, _ ...RegisterProcessOption) HandlerRegistration {
+	return ProcessRegistration{h}
+}
+
+// RegisterIntegration registers an [IntegrationMessageHandler] with an
+// [Application].
+//
+// It is used as an argument to the Handlers() method of
+// [ApplicationConfigurer].
+func RegisterIntegration(h IntegrationMessageHandler, _ ...RegisterIntegrationOption) HandlerRegistration {
+	return IntegrationRegistration{h}
+}
+
+// RegisterProjection registers a [ProjectionMessageHandler] with an
+// [Application].
+//
+// It is used as an argument to the Handlers() method of
+// [ApplicationConfigurer].
+func RegisterProjection(h ProjectionMessageHandler, _ ...RegisterProjectionOption) HandlerRegistration {
+	return ProjectionRegistration{h}
+}
+
+type (
+	// HandlerRegistration is an interface implemented by all handler
+	// registration types.
+	HandlerRegistration interface{ isHandlerRegistration() }
+
+	// AggregateRegistration describes an [AggregateMessageHandler] that is to be
+	// registered with an [Application].
+	AggregateRegistration struct{ Handler AggregateMessageHandler }
+
+	// ProcessRegistration describes a [ProcessMessageHandler] that is to be
+	// registered with an [Application].
+	ProcessRegistration struct{ Handler ProcessMessageHandler }
+
+	// IntegrationRegistration describes an [IntegrationMessageHandler] that is
+	// to be registered with an [Application].
+	IntegrationRegistration struct{ Handler IntegrationMessageHandler }
+
+	// ProjectionRegistration describes a [ProjectionMessageHandler] that is to
+	// be registered with an [Application].
+	ProjectionRegistration struct{ Handler ProjectionMessageHandler }
+)
 
 type (
 	// RegisterAggregateOption is an option that affects the behavior of a call to

--- a/application_nocoverage.go
+++ b/application_nocoverage.go
@@ -1,0 +1,6 @@
+package dogma
+
+func (AggregateRegistration) isHandlerRegistration()   {}
+func (ProcessRegistration) isHandlerRegistration()     {}
+func (IntegrationRegistration) isHandlerRegistration() {}
+func (ProjectionRegistration) isHandlerRegistration()  {}

--- a/application_test.go
+++ b/application_test.go
@@ -1,0 +1,67 @@
+package dogma_test
+
+import (
+	"testing"
+
+	. "github.com/dogmatiq/dogma"
+)
+
+func TestRegisterAggregate(t *testing.T) {
+	type aggregate struct{ AggregateMessageHandler }
+
+	h := &aggregate{}
+	r := RegisterAggregate(h)
+
+	if r, ok := r.(AggregateRegistration); ok {
+		if r.Handler != h {
+			t.Fatal("unexpected handler")
+		}
+	} else {
+		t.Fatal("unexpected type")
+	}
+}
+
+func TestRegisterProcess(t *testing.T) {
+	type process struct{ ProcessMessageHandler }
+
+	h := &process{}
+	r := RegisterProcess(h)
+
+	if r, ok := r.(ProcessRegistration); ok {
+		if r.Handler != h {
+			t.Fatal("unexpected handler")
+		}
+	} else {
+		t.Fatal("unexpected type")
+	}
+}
+
+func TestRegisterIntegration(t *testing.T) {
+	type integration struct{ IntegrationMessageHandler }
+
+	h := &integration{}
+	r := RegisterIntegration(h)
+
+	if r, ok := r.(IntegrationRegistration); ok {
+		if r.Handler != h {
+			t.Fatal("unexpected handler")
+		}
+	} else {
+		t.Fatal("unexpected type")
+	}
+}
+
+func TestRegisterProjection(t *testing.T) {
+	type projection struct{ ProjectionMessageHandler }
+
+	h := &projection{}
+	r := RegisterProjection(h)
+
+	if r, ok := r.(ProjectionRegistration); ok {
+		if r.Handler != h {
+			t.Fatal("unexpected handler")
+		}
+	} else {
+		t.Fatal("unexpected type")
+	}
+}


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/blob/main/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds a `Handlers()` method to `AggregateConfigurer` and deprecates the existing `RegisterAggregate()`, `RegisterProcess()`, `RegisterIntegration()` and `RegisterProjection()` methods.

#### Why make this change?

This change allows for new handler types and options to be added in the future without introducing a compile-time BC break to engine implementations. This is part of a broader attempt to reduce the chance of *engine-facing* BC breakages so that the `dogma` module can be versioned according to semver as it applies to *application developers*.

For precedent, see the addition of the `Routes()` method for handlers in [v0.12.0](https://github.com/dogmatiq/dogma/releases/tag/v0.12.0).

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

#169 
