### PR TITLE
Add ADR regarding message order guarantees.

### DIFF
--- a/docs/adr/0022-remove-crud-application-support.md
+++ b/docs/adr/0022-remove-crud-application-support.md
@@ -6,6 +6,8 @@ Date: 2025-06-13
 
 Accepted
 
+- Referenced By [23. Message Order Guarantees](0023-message-order-guarantees.md)
+
 ## Context
 
 Dogma has historically supported both CRUD-style and event-sourced applications.

--- a/docs/adr/0023-message-order-guarantees.md
+++ b/docs/adr/0023-message-order-guarantees.md
@@ -1,0 +1,47 @@
+# 23. Message Order Guarantees
+
+Date: 2025-06-14
+
+## Status
+
+Accepted
+
+- References [22. Remove CRUD Application Support](0022-remove-crud-application-support.md)
+
+## Context
+
+In light of the removal of CRUD application support, we are able to make more
+specific guarantees about the order in which messages are delivered to an application's handlers.
+
+## Decision
+
+We will document the following claims about delivery order as part of the API.
+
+1. Commands are delivered in an undefined order.
+2. Events produced by integration handlers are observed in an undefined order.
+3. Events produced by a single aggregate **instance** are observed in relative
+   chronological order based on their "recorded at" time.
+4. Events produced by different instances of the same aggregate type, or by
+   different aggregate types, are observed in an undefined order.
+5. Timeouts produced by a single process instance are observed in relative
+   chronological order based on their "scheduled for" time.
+6. Timeouts produced by different instances of the same process type, or by
+   different process types, are observed in an undefined order.
+
+## Consequences
+
+The guarantees about the order of command and timeout messages have not changed,
+and should present no issues for existing applications.
+
+In practice, engines attempt to handle commands immediately, providing a weak
+chronological order guarantee, but engines must be free to defer and retry
+commands as necessary.
+
+The guarantees about the order of events have been strengthened, in the case of
+events produced by a single aggregate instance. Previously there were **no**
+guarantees about the order of events, regardless of their source.
+
+Even in the case where there is no practical change to the behavior, we can
+now document these guarantees more explicitly, which may serve to make
+application developers more aware of the requirement that they must
+design their handlers around these guarantees.

--- a/docs/adr/0023-message-order-guarantees.md
+++ b/docs/adr/0023-message-order-guarantees.md
@@ -15,33 +15,41 @@ specific guarantees about the order in which messages are delivered to an applic
 
 ## Decision
 
-We will document the following claims about delivery order as part of the API.
+We will update the API documentation to describe engine behavior under the
+following guarantees:
 
-1. Commands are delivered in an undefined order.
-2. Events produced by integration handlers are observed in an undefined order.
-3. Events produced by a single aggregate **instance** are observed in relative
-   chronological order based on their "recorded at" time.
-4. Events produced by different instances of the same aggregate type, or by
-   different aggregate types, are observed in an undefined order.
-5. Timeouts produced by a single process instance are observed in relative
-   chronological order based on their "scheduled for" time.
-6. Timeouts produced by different instances of the same process type, or by
-   different process types, are observed in an undefined order.
+1. Command order is **undefined**.
+2. Events from the same aggregate instance preserve their **recorded order**.
+3. Events from the same scope preserve their **recorded order**.
+4. Relative order of events from different scopes is otherwise **undefined**.
+5. Timeouts from the same process instance follow a weak total order by
+   "scheduled for" time.
+6. Relative order of timeouts from different instances of the same process type,
+   or from different process types, is **undefined**.
+
+These rules define the **observable ordering semantics** that the engine must
+exhibit. They do not imply any specific behavior around concurrency, retry
+semantics, or other implementation details.
 
 ## Consequences
 
-The guarantees about the order of command and timeout messages have not changed,
-and should present no issues for existing applications.
+The guarantees around command and timeout ordering are unchanged and should pose
+no issues for existing applications.
 
-In practice, engines attempt to handle commands immediately, providing a weak
-chronological order guarantee, but engines must be free to defer and retry
+In practice, engines attempt to handle commands immediately, providing an
+approximate chronological order; however, they are free to defer and retry
 commands as necessary.
 
-The guarantees about the order of events have been strengthened, in the case of
-events produced by a single aggregate instance. Previously there were **no**
-guarantees about the order of events, regardless of their source.
+The use of a weak total order for timeouts makes the ordering of timeouts with
+the same "scheduled for" time explicitly undefined. This matches the behavior of
+current engine implementations and clarifies what was previously underspecified.
 
-Even in the case where there is no practical change to the behavior, we can
-now document these guarantees more explicitly, which may serve to make
-application developers more aware of the requirement that they must
-design their handlers around these guarantees.
+The guarantees around event ordering have been strengthened. Previously, there
+were no guarantees about the order of events, regardless of their source. Where
+events are now guaranteed to be observed in recorded order, this does not imply
+that their "recorded at" time is monotonic; it simply reflects the system clock
+at the time of recording.
+
+Even where the behavior is unchanged in practice, these rules allow us to
+document the guarantees more explicitly, making it clearer to application
+developers that handler logic must be designed around these constraints.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,3 +33,4 @@ the ADR documents.
 * [20. Constraints on Identifier Values](0020-identifier-constraints.md)
 * [21. Remove Handler Timeout Hints](0021-remove-handler-timeout-hints.md)
 * [22. Remove CRUD Application Support](0022-remove-crud-application-support.md)
+* [23. Message Order Guarantees](0023-message-order-guarantees.md)


### PR DESCRIPTION
This PR introduces an ADR to document the message order guarantees that we can make in light of removing support for CRUD applications #174.
