### PR TITLE
Update readme to reflect dropping of CRUD support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,35 +13,37 @@ Build message-based, event-sourced applications in Go.
 
 ## Overview
 
-Dogma is a comprehensive set of tools for building message-based, event-sourced
+Dogma is a comprehensive suite of tools for building robust message-driven
 applications in Go.
 
-In Dogma, an **application** implements business logic by consuming and
-producing messages. The application is strictly separated from the **engine**,
-which handles message delivery and data persistence.
+It includes core runtime interfaces for application logic and message delivery,
+along with tools for testing, static analysis, and application exploration.
 
 ## Features
 
-- **Event-sourced persistence**: Dogma applications are event-sourced, meaning
-  that all changes to the application's state are recorded as a sequence of
-  events. This allows for easy auditing, debugging, and rebuilding of
-  application state.
+- **Event-sourced by design** – Every state change is persisted as an immutable
+  domain event. This enables full auditability and allows read-optimized views
+  to be built or rebuilt from the event history at any time.
 
-- **Built for [Domain Driven Design]**: The API uses DDD concepts to help
-  developers align their understanding of the application's business logic with
-  its implementation.
+- **Grounded in [Domain-Driven Design]** – Dogma adopts core DDD concepts to
+  guide how applications are decomposed and how messages flow between
+  components.
 
-- **Flexible message format**: Supports any Go type that can be serialized as a
-  byte slice, with built-in support for JSON and Protocol Buffers.
+- **High-level testing** – The [testkit] module encourages verification of
+  application behavior by making assertions about domain events, rather than
+  inspecting state. It integrates seamlessly with Go’s standard [testing]
+  package.
 
-- **First-class testing**: Dogma's [testkit] module runs isolated behavioral
-  tests of your application.
+- **Native introspection** – Dogma's static analysis tools visualize message
+  flow and application structure, enabling discovery of domain events across
+  large codebases and multi-application projects.
 
-- **Engine-agnostic applications**: Choose the engine with the best messaging
-  and persistence semantics for your application.
+- **Domain and infrastructure separation** – Domain logic is cleanly and
+  strictly separated from infrastructure concerns such as message delivery and
+  persistence.
 
-- **Built-in introspection**: Analyze application code to visualize how messages
-  traverse your applications.
+- **Type-agnostic** – Messages and application state can be any Go type that
+  marshals to a byte slice, with built-in support for JSON and Protocol Buffers.
 
 ## Repositories
 
@@ -62,7 +64,7 @@ matters.
 
 ## Concepts
 
-Dogma leans heavily on the concepts of [Domain Driven Design]. It's designed to
+Dogma leans heavily on the concepts of [Domain-Driven Design]. It's designed to
 provide a suitable platform for applications that make use of design patterns
 such as Command/Query Responsibility Segregation ([CQRS]), [Event Sourcing] and
 [Eventual Consistency].
@@ -162,9 +164,9 @@ The engine manages each aggregate instance's state. State changes are
 by one command are always visible to future commands routed to the same
 instance.
 
-Aggregates can be a difficult concept to grasp. The book [Domain Driven Design
+Aggregates can be a difficult concept to grasp. The book [Domain-Driven Design
 Distilled], by Vaughn Vernon offers a suitable introduction to aggregates and
-the other elements of domain driven design.
+the other elements of domain-driven design.
 
 ### Process
 
@@ -225,13 +227,14 @@ database systems, such as PostgreSQL, MySQL, DynamoDB and others.
 [`dogma.timeout`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#Timeout
 [api documentation]: https://pkg.go.dev/github.com/dogmatiq/dogma
 [cqrs]: https://martinfowler.com/bliki/CQRS.html
-[domain driven design distilled]: https://www.amazon.com/Domain-Driven-Design-Distilled-Vaughn-Vernon/dp/0134434420
-[domain driven design]: https://en.wikipedia.org/wiki/Domain-driven_design
+[domain-driven design distilled]: https://www.amazon.com/Domain-Driven-Design-Distilled-Vaughn-Vernon/dp/0134434420
+[domain-driven design]: https://en.wikipedia.org/wiki/Domain-driven_design
 [event sourcing]: https://martinfowler.com/eaaDev/EventSourcing.html
 [eventual consistency]: https://en.wikipedia.org/wiki/Eventual_consistency
 [example]: https://github.com/dogmatiq/example
 [immediate consistency]: http://www.informit.com/articles/article.aspx?p=2020371&seqNum=2
 [projectionkit]: https://github.com/dogmatiq/projectionkit
 [rfc 2119]: https://tools.ietf.org/html/rfc2119
+[testing]: https://pkg.go.dev/testing
 [testkit]: https://github.com/dogmatiq/testkit
 [veracity]: https://github.com/dogmatiq/veracity

--- a/README.md
+++ b/README.md
@@ -57,14 +57,13 @@ build, test, analyze, and run message-driven applications.
 
 - [dogma] (this repository) – Defines the API for building applications.
 - [testkit] – Utilities for testing Dogma applications.
-- [projectionkit] – Utilities for building [projections][concept/projection] in popular database systems.
-- [example] – An example Dogma application that implements basic banking features.
+- [projectionkit] – Utilities for building [projections][concepts/projection] in popular database systems.
 
 ### Engines
 
-A core Dogma concept is that of the [engine] — a Go module embedded within your
-application binary that orchestrates message delivery, state persistence, and
-the execution of application logic.
+An important Dogma concept is that of the [engine][concepts/engine] — a Go module embedded within
+your application binary that orchestrates message delivery, state persistence,
+and the execution of application logic.
 
 - [verity] – The original Dogma engine, designed to handle typical application
   loads in smaller deployments. While production-ready, Verity does not support
@@ -86,10 +85,23 @@ rule-following, but about embracing consistent patterns that enable rich tooling
 and clarity in complex systems — without sacrificing flexibility where it
 matters.
 
+## Getting Started
+
+If you're new to Dogma, we recommend starting with the [concepts] document to
+gain a solid understanding of the core ideas and terminology used throughout the
+ecosystem.
+
+You can also explore the [example] application for a practical, working
+implementation that demonstrates key concepts in action.
+
+For a detailed reference, see the [API documentation].
+
 <!-- references -->
 
-[engine]: TODO
-[projection]: TODO
+[api documentation]: https://pkg.go.dev/github.com/dogmatiq/dogma
+[concepts]: docs/concepts.md
+[concepts/engine]: docs/concepts.md#engine
+[concepts/projection]: docs/concepts.md#projection
 [dogma]: https://github.com/dogmatiq/dogma
 [domain-driven design]: https://en.wikipedia.org/wiki/Domain-driven_design
 [event sourcing]: https://martinfowler.com/eaaDev/EventSourcing.html

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Dogma
 
-Build message-based, event-sourced applications in Go.
+Build message-driven, event-sourced applications in Go.
 
 [![Documentation](https://img.shields.io/badge/go.dev-documentation-007d9c?&style=for-the-badge)](https://pkg.go.dev/github.com/dogmatiq/dogma)
 [![Latest Version](https://img.shields.io/github/tag/dogmatiq/dogma.svg?&style=for-the-badge&label=semver)](https://github.com/dogmatiq/dogma/releases)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Build message-based, event-sourced applications in Go.
 Dogma is a comprehensive suite of tools for building robust message-driven
 applications in Go.
 
-It includes core runtime interfaces for application logic and message delivery,
-along with tools for testing, static analysis, and application exploration.
+It provides an abstraction for describing your application’s business logic with
+strict separation from components responsible for message delivery and
+persistence.
 
 ## Features
 
@@ -30,7 +31,7 @@ along with tools for testing, static analysis, and application exploration.
   components.
 
 - **High-level testing** – The [testkit] module encourages verification of
-  application behavior by making assertions about domain events, rather than
+  application behavior by making assertions about domain events rather than
   inspecting state. It integrates seamlessly with Go’s standard [testing]
   package.
 
@@ -44,6 +45,10 @@ along with tools for testing, static analysis, and application exploration.
 
 - **Type-agnostic** – Messages and application state can be any Go type that
   marshals to a byte slice, with built-in support for JSON and Protocol Buffers.
+
+- **Flexible persistence** – Support for a range of storage options such as
+  PostgreSQL and cloud services like DynamoDB, enabling use across diverse
+  environments.
 
 ## Repositories
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Dogma is a comprehensive suite of tools for building robust message-driven
 applications in Go.
 
 It provides an abstraction for describing your application’s business logic with
-strict separation from components responsible for message delivery and
+strict separation from the "engine" responsible for message delivery and
 persistence.
 
 ## Features
 
-- **Event-sourced by design** – Every state change is persisted as an immutable
+- **[Event sourcing]** – Every state change is persisted as an immutable
   domain event. This enables full auditability and allows read-optimized views
   to be built or rebuilt from the event history at any time.
 
@@ -40,24 +40,43 @@ persistence.
   large codebases and multi-application projects.
 
 - **Domain and infrastructure separation** – Domain logic is cleanly and
-  strictly separated from infrastructure concerns such as message delivery and
-  persistence.
+  strictly separated from infrastructure concerns such as message delivery,
+  persistence and telemetry.
 
-- **Type-agnostic** – Messages and application state can be any Go type that
-  marshals to a byte slice, with built-in support for JSON and Protocol Buffers.
+- **Type-agnostic** – Messages and application state can be any Go type that can
+  be marshaled to a byte slice, with built-in support for JSON and Protocol
+  Buffers.
 
 - **Flexible persistence** – Support for a range of storage options such as
-  PostgreSQL and cloud services like DynamoDB, enabling use across diverse
-  environments.
+  PostgreSQL and Amazon DynamoDB, enabling use across diverse environments.
 
-## Repositories
+## Ecosystem
 
-This repository contains the Go interfaces that form the contract between the
-application and the engine.
+Dogma is a collection of Go modules that together provide the tools needed to
+build, test, analyze, and run message-driven applications.
 
-- [testkit]: Utilities for black-box testing of Dogma applications.
-- [projectionkit]: Utilities for building [projections](#projection) in popular database systems.
-- [example]: An example Dogma application that implements basic banking features.
+- [dogma] (this repository) – Defines the API for building applications.
+- [testkit] – Utilities for testing Dogma applications.
+- [projectionkit] – Utilities for building [projections][concept/projection] in popular database systems.
+- [example] – An example Dogma application that implements basic banking features.
+
+### Engines
+
+A core Dogma concept is that of the [engine] — a Go module embedded within your
+application binary that orchestrates message delivery, state persistence, and
+the execution of application logic.
+
+- [verity] – The original Dogma engine, designed to handle typical application
+  loads in smaller deployments. While production-ready, Verity does not support
+  horizontal scaling of individual applications, using a fail-over model
+  instead.
+
+- [veracity] (under development) – The next-generation Dogma engine built for
+  horizontal scalability and distributed workloads. Longer term, Veracity is
+  intended to entirely replace Verity, becoming _the_ Dogma engine.
+
+For completeness, note that [testkit] also provides an engine implementation
+used to execute and inspect application behavior without persisting state.
 
 ## Why "Dogma"?
 
@@ -67,179 +86,16 @@ rule-following, but about embracing consistent patterns that enable rich tooling
 and clarity in complex systems — without sacrificing flexibility where it
 matters.
 
-## Concepts
-
-Dogma leans heavily on the concepts of [Domain-Driven Design]. It's designed to
-provide a suitable platform for applications that make use of design patterns
-such as Command/Query Responsibility Segregation ([CQRS]), [Event Sourcing] and
-[Eventual Consistency].
-
-The following concepts are core to Dogma's design, and should be well understood
-by any developer wishing to build an application:
-
-- [Message](#message)
-- [Message handler](#message-handler)
-- [Application](#application)
-- [Engine](#engine)
-- [Aggregate](#aggregate)
-- [Process](#process)
-- [Integration](#integration)
-- [Projection](#projection)
-
-### Message
-
-A **message** is a data structure that represents a **command**, **event** or
-**timeout** within an application.
-
-A command is a request to make a single atomic change to the application's
-state. An event indicates that the state has changed in some way. A single
-command can produce any number of events, including zero.
-
-A timeout helps model business logic that depends on the passage of time.
-
-Messages must implement the appropriate interface; one of [`dogma.Command`],
-[`dogma.Event`] or [`dogma.Timeout`].
-
-### Message handler
-
-A message **handler** is a component of an application that acts upon messages
-it receives.
-
-Each handler specifies the message types it expects to receive. These message
-are **routed** to the handler by the [engine](#engine).
-
-Command messages are always routed to a single handler. Event messages may be
-routed to any number of handlers, including zero. Timeout messages are always
-routed back to the handler that produced them.
-
-Dogma defines four handler types, one each for [aggregates](#aggregate),
-[processes](#process), [integrations](#integration) and
-[projections](#projection). These concepts are described in more detail below.
-
-### Application
-
-An **application** is a collection of [message handlers](#message-handler) that
-work together as a unit. Typically, each application encapsulates a specific
-business (sub-)domain or "bounded-context".
-
-Each application is represented by an implementation of the
-[`dogma.Application`] interface.
-
-### Engine
-
-An engine is a Go module that delivers messages to an
-[application](#application) and persists the application's state.
-
-A Dogma application can run on any Dogma engine. The choice of engine brings
-with it a set of guarantees about how the application behaves, for example:
-
-- **Consistency**: Different engines may provide different levels of
-  consistency guarantees, such as [immediate consistency] or [eventual
-  consistency].
-
-- **Persistence**: The engine may offer a choice of persistence mechanisms for
-  application state, such as in-memory, on-disk, or in a remote database.
-
-- **Scalability**: The engine may provide a choice of scalability models, such
-  as single-node or multi-node.
-
-This repository is not itself an engine implementation. It defines the API that
-engines and applications use to interact.
-
-One example of a Dogma engine is [Veracity].
-
-### Aggregate
-
-An **aggregate** is an entity that encapsulates a specific part of an
-application's business logic and its associated state. Each **instance** of an
-aggregate represents a unique occurrence of that entity within the application.
-
-Each aggregate has an associated implementation of the
-[`dogma.AggregateMessageHandler`] interface. The [engine](#engine) routes
-command [messages](#message) to the handler to change the state of specific
-instances. Such changes are represented by event messages.
-
-An important responsibility of an aggregate is to enforce the invariants of the
-business domain. These are the rules that must hold true at all times. For
-example, in a hypothetical banking system, an aggregate representing a
-customer's account balance must ensure that the balance never goes below zero.
-
-The engine manages each aggregate instance's state. State changes are
-["immediately consistent"][immediate consistency] meaning that the changes made
-by one command are always visible to future commands routed to the same
-instance.
-
-Aggregates can be a difficult concept to grasp. The book [Domain-Driven Design
-Distilled], by Vaughn Vernon offers a suitable introduction to aggregates and
-the other elements of domain-driven design.
-
-### Process
-
-A **process** automates a long running business process. In particular, they can
-coordinate changes across multiple [aggregate](#aggregate) instances, or between
-aggregates and [integrations](#integration).
-
-Like aggregates, processes encapsulate related logic and state. Each
-**instance** of a process represents a unique occurrence of that process within
-the application.
-
-Each process has an associated implementation of the
-[`dogma.ProcessMessageHandler`] interface. The [engine](#engine) routes event
-[messages](#message), which produces commands to execute.
-
-A process may use timeout messages to model business processes with time-based
-logic. The engine routes timeout messages back to the process instance that
-produced them at the specified time.
-
-Processes use command messages to make changes to the application's state.
-Because each command represents a _separate_ atomic change, the results of a
-process are ["eventually consistent"][eventual consistency].
-
-### Integration
-
-An **integration** is a message handler that interacts with some external
-non-message-based system.
-
-Each integration is an implementation of the [`dogma.IntegrationMessageHandler`]
-interface. The [engine](#engine) routes command [messages](#message) to the
-handler which interacts with some external system. Integrations may optionally
-produce event messages that represent the results of their interactions.
-
-Integrations are stateless from the perspective of the engine.
-
-### Projection
-
-A **projection** builds a partial view of the application's state from the
-events that occur.
-
-Each projection is an implementation of the [`dogma.ProjectionMessageHandler`]
-interface. The [engine](#engine) routes event [messages](#message) to the
-handler which typically updates a read-optimized database of some kind. This
-view is often referred to as a "read model".
-
-The [projectionkit] module provides tools for building read-models in popular
-database systems, such as PostgreSQL, MySQL, DynamoDB and others.
-
 <!-- references -->
 
-[`dogma.aggregatemessagehandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#AggregateMessageHandler
-[`dogma.application`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#Application
-[`dogma.integrationmessagehandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#IntegrationMessageHandler
-[`dogma.processmessagehandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#ProcessMessageHandler
-[`dogma.projectionmessagehandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#ProjectionMessageHandler
-[`dogma.command`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#Command
-[`dogma.event`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#Event
-[`dogma.timeout`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#Timeout
-[api documentation]: https://pkg.go.dev/github.com/dogmatiq/dogma
-[cqrs]: https://martinfowler.com/bliki/CQRS.html
-[domain-driven design distilled]: https://www.amazon.com/Domain-Driven-Design-Distilled-Vaughn-Vernon/dp/0134434420
+[engine]: TODO
+[projection]: TODO
+[dogma]: https://github.com/dogmatiq/dogma
 [domain-driven design]: https://en.wikipedia.org/wiki/Domain-driven_design
 [event sourcing]: https://martinfowler.com/eaaDev/EventSourcing.html
-[eventual consistency]: https://en.wikipedia.org/wiki/Eventual_consistency
 [example]: https://github.com/dogmatiq/example
-[immediate consistency]: http://www.informit.com/articles/article.aspx?p=2020371&seqNum=2
 [projectionkit]: https://github.com/dogmatiq/projectionkit
-[rfc 2119]: https://tools.ietf.org/html/rfc2119
 [testing]: https://pkg.go.dev/testing
 [testkit]: https://github.com/dogmatiq/testkit
 [veracity]: https://github.com/dogmatiq/veracity
+[verity]: https://github.com/dogmatiq/verity

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Dogma
 
-Build message-based applications in Go.
+Build message-based, event-sourced applications in Go.
 
 [![Documentation](https://img.shields.io/badge/go.dev-documentation-007d9c?&style=for-the-badge)](https://pkg.go.dev/github.com/dogmatiq/dogma)
 [![Latest Version](https://img.shields.io/github/tag/dogmatiq/dogma.svg?&style=for-the-badge&label=semver)](https://github.com/dogmatiq/dogma/releases)
@@ -13,15 +13,21 @@ Build message-based applications in Go.
 
 ## Overview
 
-Dogma is a toolkit for building message-based applications in Go.
+Dogma is a comprehensive set of tools for building message-based, event-sourced
+applications in Go.
 
 In Dogma, an **application** implements business logic by consuming and
-producing messages . The application is strictly separated from the **engine**,
+producing messages. The application is strictly separated from the **engine**,
 which handles message delivery and data persistence.
 
 ## Features
 
-- **Built for [Domain Driven Design]**: The API uses DDD terminology to help
+- **Event-sourced persistence**: Dogma applications are event-sourced, meaning
+  that all changes to the application's state are recorded as a sequence of
+  events. This allows for easy auditing, debugging, and rebuilding of
+  application state.
+
+- **Built for [Domain Driven Design]**: The API uses DDD concepts to help
   developers align their understanding of the application's business logic with
   its implementation.
 
@@ -37,7 +43,10 @@ which handles message delivery and data persistence.
 - **Built-in introspection**: Analyze application code to visualize how messages
   traverse your applications.
 
-## Related repositories
+## Repositories
+
+This repository contains the Go interfaces that form the contract between the
+application and the engine.
 
 - [testkit]: Utilities for black-box testing of Dogma applications.
 - [projectionkit]: Utilities for building [projections](#projection) in popular database systems.
@@ -73,13 +82,13 @@ command can produce any number of events, including zero.
 
 A timeout helps model business logic that depends on the passage of time.
 
-Messages must implement the appropriate interface: `Command`, `Event` or
-`Timeout`.
+Messages must implement the appropriate interface; one of [`dogma.Command`],
+[`dogma.Event`] or [`dogma.Timeout`].
 
 ### Message handler
 
-A message **handler** is part of an application that acts upon messages it
-receives.
+A message **handler** is a component of an application that acts upon messages
+it receives.
 
 Each handler specifies the message types it expects to receive. These message
 are **routed** to the handler by the [engine](#engine).
@@ -98,8 +107,8 @@ An **application** is a collection of [message handlers](#message-handler) that
 work together as a unit. Typically, each application encapsulates a specific
 business (sub-)domain or "bounded-context".
 
-The application is represented by an implementation of the [`dogma.Application`]
-interface.
+Each application is represented by an implementation of the
+[`dogma.Application`] interface.
 
 ### Engine
 
@@ -113,15 +122,8 @@ with it a set of guarantees about how the application behaves, for example:
   consistency guarantees, such as [immediate consistency] or [eventual
   consistency].
 
-- **Message delivery**: One engine may deliver messages in the same order that
-  they were produced, while another may process messages out of order or in
-  batches.
-
 - **Persistence**: The engine may offer a choice of persistence mechanisms for
   application state, such as in-memory, on-disk, or in a remote database.
-
-- **Data model**: The engine may provide a choice of data models for
-  application state, such as relational or document-oriented.
 
 - **Scalability**: The engine may provide a choice of scalability models, such
   as single-node or multi-node.
@@ -171,8 +173,8 @@ Each process has an associated implementation of the
 [messages](#message), which produces commands to execute.
 
 A process may use timeout messages to model business processes with time-based
-logic. The engine always routes timeout messages back to the process instance
-that produced them.
+logic. The engine routes timeout messages back to the process instance that
+produced them at the specified time.
 
 Processes use command messages to make changes to the application's state.
 Because each command represents a _separate_ atomic change, the results of a
@@ -198,11 +200,10 @@ events that occur.
 Each projection is an implementation of the [`dogma.ProjectionMessageHandler`]
 interface. The [engine](#engine) routes event [messages](#message) to the
 handler which typically updates a read-optimized database of some kind. This
-view is often referred to as a "read model" or "query model".
+view is often referred to as a "read model".
 
-The [projectionkit] module provides engine-agnostic tools for building
-projections in popular database systems, such as PostgreSQL, MySQL, DynamoDB and
-others.
+The [projectionkit] module provides tools for building read-models in popular
+database systems, such as PostgreSQL, MySQL, DynamoDB and others.
 
 <!-- references -->
 
@@ -211,6 +212,9 @@ others.
 [`dogma.integrationmessagehandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#IntegrationMessageHandler
 [`dogma.processmessagehandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#ProcessMessageHandler
 [`dogma.projectionmessagehandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#ProjectionMessageHandler
+[`dogma.command`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#Command
+[`dogma.event`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#Event
+[`dogma.timeout`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#Timeout
 [api documentation]: https://pkg.go.dev/github.com/dogmatiq/dogma
 [cqrs]: https://martinfowler.com/bliki/CQRS.html
 [domain driven design distilled]: https://www.amazon.com/Domain-Driven-Design-Distilled-Vaughn-Vernon/dp/0134434420

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ application and the engine.
 - [projectionkit]: Utilities for building [projections](#projection) in popular database systems.
 - [example]: An example Dogma application that implements basic banking features.
 
+## Why "Dogma"?
+
+The name _Dogma_ is a tongue-in-cheek nod to the project's strong opinions about
+how message-driven applications should be structured. It's not about rigid
+rule-following, but about embracing consistent patterns that enable rich tooling
+and clarity in complex systems — without sacrificing flexibility where it
+matters.
+
 ## Concepts
 
 Dogma leans heavily on the concepts of [Domain Driven Design]. It's designed to

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,11 +1,7 @@
-## Concepts
+# Concepts
 
-In Dogma, an **application** implements business logic by consuming and
-producing messages. The application is strictly separated from the **engine**,
-which handles message delivery and data persistence.
-
-Dogma leans heavily on the concepts of [Domain-Driven Design]. It's designed to
-provide a suitable platform for applications that make use of design patterns
+[Dogma] leans heavily on the concepts of [Domain-Driven Design]. It's designed
+to provide a suitable platform for applications that make use of design patterns
 such as Command/Query Responsibility Segregation ([CQRS]), [Event Sourcing] and
 [Eventual Consistency].
 
@@ -21,7 +17,7 @@ by any developer wishing to build an application:
 - [Integration](#integration)
 - [Projection](#projection)
 
-### Message
+## Message
 
 A **message** is a data structure that represents a **command**, **event** or
 **timeout** within an application.
@@ -35,7 +31,7 @@ A timeout helps model business logic that depends on the passage of time.
 Messages must implement the appropriate interface; one of [`dogma.Command`],
 [`dogma.Event`] or [`dogma.Timeout`].
 
-### Message handler
+## Message handler
 
 A message **handler** is a component of an application that acts upon messages
 it receives.
@@ -51,7 +47,7 @@ Dogma defines four handler types, one each for [aggregates](#aggregate),
 [processes](#process), [integrations](#integration) and
 [projections](#projection). These concepts are described in more detail below.
 
-### Application
+## Application
 
 An **application** is a collection of [message handlers](#message-handler) that
 work together as a unit. Typically, each application encapsulates a specific
@@ -60,7 +56,7 @@ business (sub-)domain or "bounded-context".
 Each application is represented by an implementation of the
 [`dogma.Application`] interface.
 
-### Engine
+## Engine
 
 An engine is a Go module that delivers messages to an
 [application](#application) and persists the application's state.
@@ -83,7 +79,7 @@ engines and applications use to interact.
 
 One example of a Dogma engine is [Veracity].
 
-### Aggregate
+## Aggregate
 
 An **aggregate** is an entity that encapsulates a specific part of an
 application's business logic and its associated state. Each **instance** of an
@@ -108,7 +104,7 @@ Aggregates can be a difficult concept to grasp. The book [Domain-Driven Design
 Distilled], by Vaughn Vernon offers a suitable introduction to aggregates and
 the other elements of domain-driven design.
 
-### Process
+## Process
 
 A **process** automates a long running business process. In particular, they can
 coordinate changes across multiple [aggregate](#aggregate) instances, or between
@@ -130,7 +126,7 @@ Processes use command messages to make changes to the application's state.
 Because each command represents a _separate_ atomic change, the results of a
 process are ["eventually consistent"][eventual consistency].
 
-### Integration
+## Integration
 
 An **integration** is a message handler that interacts with some external
 non-message-based system.
@@ -142,7 +138,7 @@ produce event messages that represent the results of their interactions.
 
 Integrations are stateless from the perspective of the engine.
 
-### Projection
+## Projection
 
 A **projection** builds a partial view of the application's state from the
 events that occur.
@@ -165,7 +161,6 @@ database systems, such as PostgreSQL, MySQL, DynamoDB and others.
 [`dogma.command`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#Command
 [`dogma.event`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#Event
 [`dogma.timeout`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#Timeout
-[api documentation]: https://pkg.go.dev/github.com/dogmatiq/dogma
 [cqrs]: https://martinfowler.com/bliki/CQRS.html
 [dogma]: https://github.com/dogmatiq/dogma
 [domain-driven design distilled]: https://www.amazon.com/Domain-Driven-Design-Distilled-Vaughn-Vernon/dp/0134434420
@@ -175,8 +170,4 @@ database systems, such as PostgreSQL, MySQL, DynamoDB and others.
 [example]: https://github.com/dogmatiq/example
 [immediate consistency]: http://www.informit.com/articles/article.aspx?p=2020371&seqNum=2
 [projectionkit]: https://github.com/dogmatiq/projectionkit
-[rfc 2119]: https://tools.ietf.org/html/rfc2119
-[testing]: https://pkg.go.dev/testing
-[testkit]: https://github.com/dogmatiq/testkit
 [veracity]: https://github.com/dogmatiq/veracity
-[verity]: https://github.com/dogmatiq/verity

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,182 @@
+## Concepts
+
+In Dogma, an **application** implements business logic by consuming and
+producing messages. The application is strictly separated from the **engine**,
+which handles message delivery and data persistence.
+
+Dogma leans heavily on the concepts of [Domain-Driven Design]. It's designed to
+provide a suitable platform for applications that make use of design patterns
+such as Command/Query Responsibility Segregation ([CQRS]), [Event Sourcing] and
+[Eventual Consistency].
+
+The following concepts are core to Dogma's design, and should be well understood
+by any developer wishing to build an application:
+
+- [Message](#message)
+- [Message handler](#message-handler)
+- [Application](#application)
+- [Engine](#engine)
+- [Aggregate](#aggregate)
+- [Process](#process)
+- [Integration](#integration)
+- [Projection](#projection)
+
+### Message
+
+A **message** is a data structure that represents a **command**, **event** or
+**timeout** within an application.
+
+A command is a request to make a single atomic change to the application's
+state. An event indicates that the state has changed in some way. A single
+command can produce any number of events, including zero.
+
+A timeout helps model business logic that depends on the passage of time.
+
+Messages must implement the appropriate interface; one of [`dogma.Command`],
+[`dogma.Event`] or [`dogma.Timeout`].
+
+### Message handler
+
+A message **handler** is a component of an application that acts upon messages
+it receives.
+
+Each handler specifies the message types it expects to receive. These message
+are **routed** to the handler by the [engine](#engine).
+
+Command messages are always routed to a single handler. Event messages may be
+routed to any number of handlers, including zero. Timeout messages are always
+routed back to the handler that produced them.
+
+Dogma defines four handler types, one each for [aggregates](#aggregate),
+[processes](#process), [integrations](#integration) and
+[projections](#projection). These concepts are described in more detail below.
+
+### Application
+
+An **application** is a collection of [message handlers](#message-handler) that
+work together as a unit. Typically, each application encapsulates a specific
+business (sub-)domain or "bounded-context".
+
+Each application is represented by an implementation of the
+[`dogma.Application`] interface.
+
+### Engine
+
+An engine is a Go module that delivers messages to an
+[application](#application) and persists the application's state.
+
+A Dogma application can run on any Dogma engine. The choice of engine brings
+with it a set of guarantees about how the application behaves, for example:
+
+- **Consistency**: Different engines may provide different levels of
+  consistency guarantees, such as [immediate consistency] or [eventual
+  consistency].
+
+- **Persistence**: The engine may offer a choice of persistence mechanisms for
+  application state, such as in-memory, on-disk, or in a remote database.
+
+- **Scalability**: The engine may provide a choice of scalability models, such
+  as single-node or multi-node.
+
+This repository is not itself an engine implementation. It defines the API that
+engines and applications use to interact.
+
+One example of a Dogma engine is [Veracity].
+
+### Aggregate
+
+An **aggregate** is an entity that encapsulates a specific part of an
+application's business logic and its associated state. Each **instance** of an
+aggregate represents a unique occurrence of that entity within the application.
+
+Each aggregate has an associated implementation of the
+[`dogma.AggregateMessageHandler`] interface. The [engine](#engine) routes
+command [messages](#message) to the handler to change the state of specific
+instances. Such changes are represented by event messages.
+
+An important responsibility of an aggregate is to enforce the invariants of the
+business domain. These are the rules that must hold true at all times. For
+example, in a hypothetical banking system, an aggregate representing a
+customer's account balance must ensure that the balance never goes below zero.
+
+The engine manages each aggregate instance's state. State changes are
+["immediately consistent"][immediate consistency] meaning that the changes made
+by one command are always visible to future commands routed to the same
+instance.
+
+Aggregates can be a difficult concept to grasp. The book [Domain-Driven Design
+Distilled], by Vaughn Vernon offers a suitable introduction to aggregates and
+the other elements of domain-driven design.
+
+### Process
+
+A **process** automates a long running business process. In particular, they can
+coordinate changes across multiple [aggregate](#aggregate) instances, or between
+aggregates and [integrations](#integration).
+
+Like aggregates, processes encapsulate related logic and state. Each
+**instance** of a process represents a unique occurrence of that process within
+the application.
+
+Each process has an associated implementation of the
+[`dogma.ProcessMessageHandler`] interface. The [engine](#engine) routes event
+[messages](#message), which produces commands to execute.
+
+A process may use timeout messages to model business processes with time-based
+logic. The engine routes timeout messages back to the process instance that
+produced them at the specified time.
+
+Processes use command messages to make changes to the application's state.
+Because each command represents a _separate_ atomic change, the results of a
+process are ["eventually consistent"][eventual consistency].
+
+### Integration
+
+An **integration** is a message handler that interacts with some external
+non-message-based system.
+
+Each integration is an implementation of the [`dogma.IntegrationMessageHandler`]
+interface. The [engine](#engine) routes command [messages](#message) to the
+handler which interacts with some external system. Integrations may optionally
+produce event messages that represent the results of their interactions.
+
+Integrations are stateless from the perspective of the engine.
+
+### Projection
+
+A **projection** builds a partial view of the application's state from the
+events that occur.
+
+Each projection is an implementation of the [`dogma.ProjectionMessageHandler`]
+interface. The [engine](#engine) routes event [messages](#message) to the
+handler which typically updates a read-optimized database of some kind. This
+view is often referred to as a "read model".
+
+The [projectionkit] module provides tools for building read-models in popular
+database systems, such as PostgreSQL, MySQL, DynamoDB and others.
+
+<!-- references -->
+
+[`dogma.aggregatemessagehandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#AggregateMessageHandler
+[`dogma.application`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#Application
+[`dogma.integrationmessagehandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#IntegrationMessageHandler
+[`dogma.processmessagehandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#ProcessMessageHandler
+[`dogma.projectionmessagehandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#ProjectionMessageHandler
+[`dogma.command`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#Command
+[`dogma.event`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#Event
+[`dogma.timeout`]: https://pkg.go.dev/github.com/dogmatiq/dogma?tab=doc#Timeout
+[api documentation]: https://pkg.go.dev/github.com/dogmatiq/dogma
+[cqrs]: https://martinfowler.com/bliki/CQRS.html
+[dogma]: https://github.com/dogmatiq/dogma
+[domain-driven design distilled]: https://www.amazon.com/Domain-Driven-Design-Distilled-Vaughn-Vernon/dp/0134434420
+[domain-driven design]: https://en.wikipedia.org/wiki/Domain-driven_design
+[event sourcing]: https://martinfowler.com/eaaDev/EventSourcing.html
+[eventual consistency]: https://en.wikipedia.org/wiki/Eventual_consistency
+[example]: https://github.com/dogmatiq/example
+[immediate consistency]: http://www.informit.com/articles/article.aspx?p=2020371&seqNum=2
+[projectionkit]: https://github.com/dogmatiq/projectionkit
+[rfc 2119]: https://tools.ietf.org/html/rfc2119
+[testing]: https://pkg.go.dev/testing
+[testkit]: https://github.com/dogmatiq/testkit
+[veracity]: https://github.com/dogmatiq/veracity
+[verity]: https://github.com/dogmatiq/verity


### PR DESCRIPTION
This PR significantly revises the README with changes prompted as a result of dropping support for CRUD applications in #174.

I have moved the "concepts" section into a separate file, which at this stage is largely unchanged and will needs its own updates to reflect #174, but I wanted to keep this PR small and digestible.

Because the changes are significant, it's probably not useful to review by looking at a diff, it'd be more valuable to get some opinions about [the document as a whole](https://github.com/dogmatiq/dogma/blob/no-crud/README.md) - it's much shorter now 😁  

