### PR TITLE
Add glossary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ ecosystem.
 You can also explore the [example] application for a practical, working
 implementation that demonstrates key concepts in action.
 
-For a detailed reference, see the [glossary] and [API documentation].
+For reference material, please see the [API documentation] and [glossary].
 
 <!-- references -->
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ ecosystem.
 You can also explore the [example] application for a practical, working
 implementation that demonstrates key concepts in action.
 
-For a detailed reference, see the [API documentation].
+For a detailed reference, see the [glossary] and [API documentation].
 
 <!-- references -->
 
@@ -105,6 +105,7 @@ For a detailed reference, see the [API documentation].
 [engine]: docs/concepts.md#engines
 [event sourcing]: https://martinfowler.com/eaaDev/EventSourcing.html
 [example]: https://github.com/dogmatiq/example
+[glossary]: docs/glossary.md
 [projectionkit]: https://github.com/dogmatiq/projectionkit
 [projections]: docs/concepts.md#handlers
 [testing]: https://pkg.go.dev/testing

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -176,6 +176,7 @@ explore the following resources:
 - The [example] repository, which contains a simple banking application with
   features such as opening accounts and transferring funds.
 - The [API documentation], for detailed information on Dogma's interfaces.
+- Browse the [glossary] to cement your understanding of Dogma's terminology.
 
 <!-- anchors -->
 
@@ -184,6 +185,10 @@ explore the following resources:
 [message handler]: #handlers
 [message handlers]: #handlers
 [application]: #applications
+
+<!-- other documentation  -->
+
+[glossary]: glossary.md
 
 <!-- go modules -->
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -120,7 +120,7 @@ A [message] that describes an action that the application has already performed.
 
 See [`dogma.Event`].
 
-### Event-sourcing
+### Event sourcing
 
 An architectural pattern in which the authoritative representation of an
 [application]'s state is provided by one or more [event streams].

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -105,7 +105,7 @@ A software development approach that emphasizes modeling software around the
 core concepts and behavior of the business domain it supports.
 
 See [domain-driven design](https://en.wikipedia.org/wiki/Domain-driven_design)
-on Wikipedia.
+for more information.
 
 ## E
 
@@ -123,7 +123,10 @@ See [`dogma.Event`].
 ### Event-sourcing
 
 An architectural pattern in which the authoritative representation of an
-application's state is provided by one or more [event streams].
+[application]'s state is provided by one or more [event streams].
+
+See [event sourcing](https://martinfowler.com/eaaDev/EventSourcing.html) for
+more information.
 
 ### Event stream
 
@@ -147,8 +150,8 @@ See:
 
 ### Identity
 
-A human-readable name and machine-readable key (UUID) that uniquely identifies
-each [application] and [message handler].
+A human-readable name and machine-readable key (UUID), specified via a
+[configurer], that uniquely identifies each [application] and [message handler].
 
 ### Instance
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -87,7 +87,7 @@ See [`dogma.Command`].
 ### Configurer
 
 An interface used by an [application] or [message handler] to configure its
-identity and declare its [routes] to the [engine].
+[identity] and declare its [routes] to the [engine].
 
 See:
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,444 @@
+# Dogma Glossary
+
+[A](#a) •
+B •
+[C](#c) •
+[D](#d) •
+[E](#e) •
+F •
+G •
+[H](#h) •
+[I](#i) •
+J •
+K •
+L •
+[M](#m) •
+N •
+O •
+[P](#p) •
+Q •
+R •
+S •
+[T](#t) •
+U •
+[V](#v) •
+[W](#w) •
+X •
+Y •
+Z
+
+## A
+
+### Aggregate
+
+A collection of related business entities that are treated as a single unit. For
+example, a shopping cart and the items within it.
+
+> [!NOTE]
+> The term originates from [domain-driven design], where it refers to a group
+> of entities that are dealt with "in aggregate". It does not refer to data
+> aggregation or summarization.
+
+> [!TIP]
+> "Aggregate" is often used informally to mean [aggregate message handler].
+
+### Aggregate command scope
+
+The [scope] in which an [aggregate message handler] handles a [command] message
+by recording [event] messages that represent changes to an [aggregate instance].
+
+See [`dogma.AggregateCommandScope`].
+
+### Aggregate instance
+
+A unique occurrence of an [aggregate] within an [application]. For example, a
+shopping cart aggregate may use a separate instance for each customer.
+
+### Aggregate message handler
+
+A [message handler] that manages the state and behavior of an [aggregate] by
+handling [command] messages and recording [event] messages.
+
+See [`dogma.AggregateMessageHandler`].
+
+### Aggregate root
+
+The primary entity within an [aggregate] through which all state changes occur.
+For example, a shopping cart aggregate that consists of a cart and its items may
+use the cart itself as its root.
+
+See [`dogma.AggregateRoot`].
+
+### Application
+
+A collection of related [message handlers] that together define the logic for a
+specific business domain.
+
+See [`dogma.Application`].
+
+## C
+
+### Command
+
+A [message] that represents a request for the application to perform an action.
+
+See [`dogma.Command`].
+
+### Configurer
+
+An interface used by an [application] or [message handler] to configure its
+identity and declare its [routes] to the [engine].
+
+See:
+
+- [`dogma.ApplicationConfigurer`]
+- [`dogma.AggregateConfigurer`]
+- [`dogma.ProcessConfigurer`]
+- [`dogma.ProjectionConfigurer`]
+- [`dogma.IntegrationConfigurer`]
+
+## D
+
+### Domain-driven design
+
+A software development approach that emphasizes modeling software around the
+core concepts and behavior of the business domain it supports.
+
+See [domain-driven design](https://en.wikipedia.org/wiki/Domain-driven_design)
+on Wikipedia.
+
+## E
+
+### Engine
+
+A runtime component that executes a Dogma [application] by delivering [messages]
+to its [message handlers] and persisting application state.
+
+### Event
+
+A [message] that describes an action that the application has already performed.
+
+See [`dogma.Event`].
+
+### Event-sourcing
+
+An architectural pattern in which the authoritative representation of an
+application's state is provided by one or more [event streams].
+
+### Event stream
+
+An immutable, ordered sequence of [event] messages.
+
+## H
+
+### Handler route
+
+A declaration by an [application], made using a [configurer], that it includes a
+specific [message handler], and incorporates that handler's [message routes].
+
+See:
+
+- [`dogma.ViaAggregate()`]
+- [`dogma.ViaProcess()`]
+- [`dogma.ViaProjection()`]
+- [`dogma.ViaIntegration()`]
+
+## I
+
+### Identity
+
+A human-readable name and machine-readable key (UUID) that uniquely identifies
+each [application] and [message handler].
+
+### Instance
+
+See [aggregate instance] or [process instance].
+
+### Integration
+
+See [integration message handler].
+
+### Integration command scope
+
+The [scope] in which an [integration message handler] handles a [command]
+message by interacting with an external system.
+
+See [`dogma.IntegrationCommandScope`].
+
+### Integration message handler
+
+A stateless [message handler] that interacts with external systems, such as a
+third-party payment API, by handling [command] messages and recording [event]
+messages to represent outcomes.
+
+See [`dogma.IntegrationMessageHandler`].
+
+## M
+
+### Message
+
+A data structure that represents a request for — or the prior occurrence of — an
+action within an [application].
+
+See:
+
+- [command]
+- [event]
+- [timeout]
+- [`dogma.Message`]
+
+### Message handler
+
+A component of an [application] that acts upon [messages] by producing
+new messages or manipulating application state.
+
+See:
+
+- [aggregate message handler]
+- [process message handler]
+- [projection message handler]
+- [integration message handler]
+
+### Message kind
+
+The category of a [message] that defines its role in the application, one of
+[command], [event], or [timeout].
+
+### Message route
+
+A declaration by a [message handler], made using a [configurer], that it
+produces or consumes a specific [message type].
+
+See:
+
+- [`dogma.HandlesCommand()`] and [`dogma.ExecutesCommand()`]
+- [`dogma.HandlesEvent()`] and [`dogma.RecordsEvent()`]
+- [`dogma.SchedulesTimeout()`]
+
+### Message type
+
+A property of a [message] that identifies its specific meaning within the
+business domain. Typically represented as a distinct Go type, such as
+`AddItemToCart` or `OrderPlaced`.
+
+## P
+
+### Process
+
+A stateful workflow within an [application] that coordinates business logic
+involving multiple [aggregate instances], [integrations] or time-sensitive
+logic.
+
+> [!TIP]
+> "Process" is often used informally to mean [process message handler].
+
+### Process event scope
+
+The [scope] in which a [process message handler] handles an [event] message by
+updating state, executing [command] messages, or scheduling [timeout] messages
+to advance the [process instance]'s workflow.
+
+See [`dogma.ProcessEventScope`].
+
+### Process instance
+
+A unique occurrence of a [process] within an [application], encapsulating the
+state of a specific execution of a workflow.
+
+### Process message handler
+
+A [message handler] that orchestrates a [process] by handling [event] messages,
+executing [command] messages and scheduling [timeout] messages.
+
+See [`dogma.ProcessMessageHandler`].
+
+### Process root
+
+The primary entity within a [process]'s state through which all changes occur.
+Named by analogy to [aggregate root].
+
+See [`dogma.ProcessRoot`].
+
+### Process timeout scope
+
+The [scope] in which a [process message handler] handles a [timeout] message at
+its scheduled time, by updating state, executing [command] messages, or
+scheduling additional [timeout] messages to advance the [process instance]'s
+workflow.
+
+See [`dogma.ProcessTimeoutScope`].
+
+### Projection
+
+A read-optimized view of (a subset of) the application's state constructed by
+observing [event] messages, typically persisted to a database.
+
+> [!TIP]
+> "Projection" is often used informally to mean [projection message handler],
+> while the resulting view is commonly called a "read-model."
+
+### Projection compact scope
+
+The [scope] in which a [projection message handler] compacts its state by
+removing or summarizing older or redundant data.
+
+See [`dogma.ProjectionCompactScope`].
+
+### Projection event scope
+
+The [scope] in which a [projection message handler] applies an [event] message
+to its [projection].
+
+See [`dogma.ProjectionEventScope`].
+
+### Projection message handler
+
+A [message handler] that builds a [projection] by handling [event] messages.
+
+See [`dogma.ProjectionMessageHandler`].
+
+### `projectionkit`
+
+A Go module that provides tools for building [projections] in various popular
+self-hosted and cloud-based database systems.
+
+See [`dogmatiq/projectionkit`].
+
+## R
+
+### Read-model
+
+See [projection].
+
+### Route
+
+See [message route] or [handler route].
+
+## S
+
+### Saga
+
+A software pattern for managing distributed transactions by applying a sequence
+of operations and, if necessary, rolling back changes through compensating
+actions.
+
+See [process].
+
+### Scope
+
+The context within which a [message handler] handles an incoming [message].
+It provides information about the message and defines the messaging operations
+available to the handler.
+
+## T
+
+### `testkit`
+
+A Go module that provides high-level tools for testing Dogma [applications].
+
+See [`dogmatiq/testkit`].
+
+### Timeout
+
+A [message] that describes an action that a [process] should take at a specific
+time in the future.
+
+See [`dogma.Timeout`].
+
+## V
+
+### Veracity
+
+An upcoming [engine] implementation built for horizontal scalability and
+distributed workloads.
+
+See [`dogmatiq/veracity`].
+
+### Verity
+
+An [engine] designed for typical application loads in smaller deployments.
+
+See [`dogmatiq/verity`].
+
+## W
+
+### Workflow
+
+See [process].
+
+<!-- anchors -->
+
+[aggregate instance]: #aggregate-instance
+[aggregate instances]: #aggregate-instance
+[aggregate message handler]: #aggregate-message-handler
+[aggregate root]: #aggregate-root
+[aggregate]: #aggregate
+[application]: #application
+[applications]: #application
+[command]: #command
+[configurer]: #configurer
+[domain-driven design]: #domain-driven-design
+[engine]: #engine
+[event streams]: #event-stream
+[event]: #event
+[handler route]: #handler-route
+[identity]: #identity
+[integration message handler]: #integration-message-handler
+[integrations]: #integration
+[message handler]: #message-handler
+[message handlers]: #message-handler
+[message route]: #message-route
+[message routes]: #message-route
+[message type]: #message-type
+[message]: #message
+[messages]: #message
+[process instance]: #process-instance
+[process message handler]: #process-message-handler
+[process]: #process
+[projection message handler]: #projection-message-handler
+[projection]: #projection
+[projections]: #projection
+[routes]: #route
+[scope]: #scope
+[timeout]: #timeout
+
+<!-- go modules -->
+
+[`dogmatiq/projectionkit`]: https://pkg.go.dev/github.com/dogmatiq/projectionkit
+[`dogmatiq/testkit`]: https://pkg.go.dev/github.com/dogmatiq/testkit
+[`dogmatiq/veracity`]: https://pkg.go.dev/github.com/dogmatiq/veracity
+[`dogmatiq/verity`]: https://pkg.go.dev/github.com/dogmatiq/verity
+
+<!-- API references -->
+
+[`dogma.AggregateCommandScope`]: https://pkg.go.dev/github.com/dogmatiq/dogma#AggregateCommandScope
+[`dogma.AggregateConfigurer`]: https://pkg.go.dev/github.com/dogmatiq/dogma#AggregateConfigurer
+[`dogma.AggregateMessageHandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma#AggregateMessageHandler
+[`dogma.AggregateRoot`]: https://pkg.go.dev/github.com/dogmatiq/dogma#AggregateRoot
+[`dogma.Application`]: https://pkg.go.dev/github.com/dogmatiq/dogma#Application
+[`dogma.ApplicationConfigurer`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ApplicationConfigurer
+[`dogma.Command`]: https://pkg.go.dev/github.com/dogmatiq/dogma#Command
+[`dogma.Event`]: https://pkg.go.dev/github.com/dogmatiq/dogma#Event
+[`dogma.ExecutesCommand()`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ExecutesCommand
+[`dogma.HandlesCommand()`]: https://pkg.go.dev/github.com/dogmatiq/dogma#HandlesCommand
+[`dogma.HandlesEvent()`]: https://pkg.go.dev/github.com/dogmatiq/dogma#HandlesEvent
+[`dogma.IntegrationCommandScope`]: https://pkg.go.dev/github.com/dogmatiq/dogma#IntegrationCommandScope
+[`dogma.IntegrationConfigurer`]: https://pkg.go.dev/github.com/dogmatiq/dogma#IntegrationConfigurer
+[`dogma.Message`]: https://pkg.go.dev/github.com/dogmatiq/dogma#Message
+[`dogma.ProcessConfigurer`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProcessConfigurer
+[`dogma.ProcessEventScope`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProcessEventScope
+[`dogma.IntegrationMessageHandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma#IntegrationMessageHandler
+[`dogma.ProjectionMessageHandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProjectionMessageHandler
+[`dogma.ProcessMessageHandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProcessMessageHandler
+[`dogma.ProcessRoot`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProcessRoot
+[`dogma.ProcessTimeoutScope`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProcessTimeoutScope
+[`dogma.ProjectionCompactScope`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProjectionCompactScope
+[`dogma.ProjectionConfigurer`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProjectionConfigurer
+[`dogma.ProjectionEventScope`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProjectionEventScope
+[`dogma.RecordsEvent()`]: https://pkg.go.dev/github.com/dogmatiq/dogma#RecordsEvent
+[`dogma.SchedulesTimeout()`]: https://pkg.go.dev/github.com/dogmatiq/dogma#SchedulesTimeout
+[`dogma.Timeout`]: https://pkg.go.dev/github.com/dogmatiq/dogma#Timeout
+[`dogma.ViaAggregate()`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ViaAggregate
+[`dogma.ViaIntegration()`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ViaIntegration
+[`dogma.ViaProcess()`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ViaProcess
+[`dogma.ViaProjection()`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ViaProjection


### PR DESCRIPTION
This PR adds a glossary of terms.

I decided to add a glossary after reworking other documentation for #174, although it's not strictly necessary for the completion of that issue.

As usual, the diff probably isn't that useful for docs. The full document is here: https://github.com/dogmatiq/dogma/blob/glossary/docs/glossary.md

I've tried to keep each entry very concise and factual, and cross-link to other definitions where appropriate. In some cases I've included terms that don't strictly come from Dogma but are used frequently in our documentation and discussions. I also may have missed some terms that should be included.

This should be the last wall-of-documentation-text PR for a little while, as I work through the actually in-code API docs.