### PR TITLE
Add `MessageValidationScope`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,14 @@ registry before they can be used in handler routes.
   the message type registry.
 - Added `Now()` method to `AggregateCommandScope`, `ProcessEventScope`,
   `ProcessTimeoutScope`, `IntegrationCommandScope` and `ProjectionEventScope`.
+- Added `WithIdempotencyKey()` option for `CommandExecutor`.
 - **[ENGINE BC]** Added `Routes()` method to `ApplicationConfigurer`.
-- **[ENGINE BC]** Added `IsHistorical()` method to `EventValidationScope`.
-- **[ENGINE BC]** Added `IsScheduled()` method to `TimeoutValidationScope`.
-- Added `WithIdempotencyKey()`.
+- **[ENGINE BC]** Added `MessageValidationScope` interface, which is embedded in
+  `CommandValidationScope`, `EventValidationScope` and `TimeoutValidationScope`.
+- **[ENGINE BC]** Added `MessageValidationScope.IsNew()` method.
+- **[ENGINE BC]** Added `RecordedAt()` method to `EventValidationScope`.
+- **[ENGINE BC]** Added `ScheduledAt()` and `ScheduledFor()` methods to
+  `TimeoutValidationScope`.
 
 ### Changed
 


### PR DESCRIPTION
This PR adds the `MessageValidationScope` interface as a common base for `CommandValidationScope`, `EventValidationScope` and `TimeoutValidationScope`.  It includes an `IsNew()` method to check if the message is being created "now" or has already been validated and persisted before.

I've also added all of the relevant `time.Time` values to each validation scope.