### PR TITLE
Refactor route and option types to use value-based interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ The format is based on [Keep a Changelog], and this project adheres to
 ## [Unreleased]
 
 This release changes how handlers are added to an application. It introduces the
-`ApplicationConfigurer.Routes()` interface to replace the `RegisterAggregate()`,
-`RegisterProcess()`, `RegisterIntegration()`, and `RegisterProjection()` method,
-which have been removed.
+`ApplicationConfigurer.Routes()` method to replace the `RegisterAggregate()`,
+`RegisterProcess()`, `RegisterIntegration()`, and `RegisterProjection()`
+methods, which have been removed.
 
 It also introduces a global message type registry. The application-defined types
 that implement `Command`, `Event`, and `Timeout` must now be added to the
@@ -25,11 +25,11 @@ registry before they can be used in handler routes.
 
 ### Added
 
+- Added `HandlerRoute` and `MessageRoute` interfaces.
 - Added `ViaAggregate()`, `ViaProcess()`, `ViaIntegration()`, and
   `ViaProjection()` for use with `ApplicationConfigurer.Routes()`.
-- Added `HandlerRoute` and `MessageRoute` interfaces.
-- Added `ViaAggregateRoute`, `ViaProcessRoute`, `ViaIntegrationRoute` and
-  `ViaProjectionRoute` types.
+- Added `AggregateHandlerRoute`, `ProcessHandlerRoute`,
+  `IntegrationHandlerRoute` and `ProjectionHandlerRoute` types.
 - Added `RegisterCommand()`, `RegisterEvent()`, and `RegisterTimeout()` for
   adding types to the message type registry. These functions panic if called
   with a pointer to a type that uses non-pointer receivers to implement the
@@ -57,8 +57,8 @@ registry before they can be used in handler routes.
 - **[BC]** Changed `ProjectionMessageHandler.HandleEvent()` to explicitly use
   event stream IDs and event offsets for OCC, instead of abstract versioned
   resources.
-- **[ENGINE BC]** Message route types now use `RegisteredMessageType` instead of
-  `reflect.Type`.
+- **[ENGINE BC]** Implementations of `MessageRoute` now use
+  `RegisteredMessageType` instead of `reflect.Type`.
 
 ### Removed
 

--- a/executor.go
+++ b/executor.go
@@ -26,7 +26,7 @@ type CommandExecutor interface {
 // ExecuteCommandOption is an option that modifies the behavior of
 // [CommandExecutor].ExecuteCommand.
 type ExecuteCommandOption interface {
-	ApplyExecuteCommandOption(executeCommandOptionsBuilder)
+	isExecuteCommandOption()
 }
 
 // WithIdempotencyKey returns an [ExecuteCommandOption] that sets a unique
@@ -38,15 +38,20 @@ func WithIdempotencyKey(key string) ExecuteCommandOption {
 	if key == "" {
 		panic("idempotency key cannot be empty")
 	}
-	return idempotencyKey{key}
+
+	return IdempotencyKeyOption{key: key}
 }
 
-type executeCommandOptionsBuilder interface {
-	IdempotencyKey(string)
+// IdempotencyKeyOption is an [ExecuteCommandOption] that sets a unique
+// identifier for a [Command].
+//
+// Use [WithIdempotencyKey] to create values of this type.
+type IdempotencyKeyOption struct {
+	nocmp
+	key string
 }
 
-type idempotencyKey struct{ k string }
-
-func (k idempotencyKey) ApplyExecuteCommandOption(b executeCommandOptionsBuilder) {
-	b.IdempotencyKey(k.k)
+// Key returns the idempotency key.
+func (o IdempotencyKeyOption) Key() string {
+	return o.key
 }

--- a/executor_nocoverage.go
+++ b/executor_nocoverage.go
@@ -1,0 +1,3 @@
+package dogma
+
+func (IdempotencyKeyOption) isExecuteCommandOption() {}

--- a/executor_test.go
+++ b/executor_test.go
@@ -6,34 +6,29 @@ import (
 	. "github.com/dogmatiq/dogma"
 )
 
-type executeCommandOptionBuilder struct {
-	IdemKey string
-}
-
-func (b *executeCommandOptionBuilder) IdempotencyKey(key string) {
-	b.IdemKey = key
-}
-
 func TestWithIdempotencyKey(t *testing.T) {
 	t.Run("it returns an option with the specified idempotency key", func(t *testing.T) {
 		const want = "<key>"
 
-		b := &executeCommandOptionBuilder{}
 		o := WithIdempotencyKey(want)
-		o.ApplyExecuteCommandOption(b)
 
-		if b.IdemKey != want {
-			t.Fatalf("unexpected idempotency key: got %q, want %q", b.IdemKey, want)
+		x, ok := o.(IdempotencyKeyOption)
+		if !ok {
+			t.Fatalf("unexpected type: got %T, want %T", o, x)
+		}
+
+		if x.Key() != want {
+			t.Fatalf("unexpected idempotency key: got %q, want %q", x.Key(), want)
 		}
 	})
 
 	t.Run("it panics if the key is empty", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Fatal("expected a panic")
-			}
-		}()
-
-		WithIdempotencyKey("")
+		expectPanic(
+			t,
+			`idempotency key cannot be empty`,
+			func() {
+				WithIdempotencyKey("")
+			},
+		)
 	})
 }

--- a/handlerroute.go
+++ b/handlerroute.go
@@ -5,7 +5,10 @@ package dogma
 //
 // Pass the returned [HandlerRoute] to [ApplicationConfigurer].Routes.
 func ViaAggregate(h AggregateMessageHandler, _ ...ViaAggregateOption) HandlerRoute {
-	return ViaAggregateRoute{Handler: h}
+	if h == nil {
+		panic("handler cannot be nil")
+	}
+	return AggregateHandlerRoute{handler: h}
 }
 
 // ViaProcess configures the [Application] to route messages to and from a
@@ -13,7 +16,10 @@ func ViaAggregate(h AggregateMessageHandler, _ ...ViaAggregateOption) HandlerRou
 //
 // Pass the returned [HandlerRoute] to [ApplicationConfigurer].Routes.
 func ViaProcess(h ProcessMessageHandler, _ ...ViaProcessOption) HandlerRoute {
-	return ViaProcessRoute{Handler: h}
+	if h == nil {
+		panic("handler cannot be nil")
+	}
+	return ProcessHandlerRoute{handler: h}
 }
 
 // ViaIntegration configures the [Application] to route messages to and from an
@@ -21,7 +27,10 @@ func ViaProcess(h ProcessMessageHandler, _ ...ViaProcessOption) HandlerRoute {
 //
 // Pass the returned [HandlerRoute] to [ApplicationConfigurer].Routes.
 func ViaIntegration(h IntegrationMessageHandler, _ ...ViaIntegrationOption) HandlerRoute {
-	return ViaIntegrationRoute{Handler: h}
+	if h == nil {
+		panic("handler cannot be nil")
+	}
+	return IntegrationHandlerRoute{handler: h}
 }
 
 // ViaProjection configures the [Application] to route messages to a
@@ -29,7 +38,10 @@ func ViaIntegration(h IntegrationMessageHandler, _ ...ViaIntegrationOption) Hand
 //
 // Pass the returned [HandlerRoute] to [ApplicationConfigurer].Routes.
 func ViaProjection(h ProjectionMessageHandler, _ ...ViaProjectionOption) HandlerRoute {
-	return ViaProjectionRoute{Handler: h}
+	if h == nil {
+		panic("handler cannot be nil")
+	}
+	return ProjectionHandlerRoute{handler: h}
 }
 
 type (
@@ -39,47 +51,44 @@ type (
 	// Use [ViaAggregate], [ViaProcess], [ViaIntegration], or [ViaProjection]
 	// to create a HandlerRoute.
 	HandlerRoute interface {
-		ApplyHandlerRoute(HandlerRoutesBuilder)
+		isHandlerRoute()
 	}
 
-	// ViaAggregateRoute is a [HandlerRoute] that represents a relationship
+	// AggregateHandlerRoute is a [HandlerRoute] that represents a relationship
 	// between the [Application] and an [AggregateMessageHandler].
 	//
-	// Avoid constructing values of this type directly; use [ViaAggregate]
-	// instead.
-	ViaAggregateRoute struct {
+	// Use [ViaAggregate] to construct values of this type.
+	AggregateHandlerRoute struct {
 		nocmp
-		Handler AggregateMessageHandler
+		handler AggregateMessageHandler
 	}
 
-	// ViaProcessRoute is a [HandlerRoute] that represents a relationship
+	// ProcessHandlerRoute is a [HandlerRoute] that represents a relationship
 	// between the [Application] and a [ProcessMessageHandler].
 	//
-	// Avoid constructing values of this type directly; use [ViaProcess]
-	// instead.
-	ViaProcessRoute struct {
+	// See [ViaProcess] to construct values of this type.
+	ProcessHandlerRoute struct {
 		nocmp
-		Handler ProcessMessageHandler
+		handler ProcessMessageHandler
 	}
 
-	// ViaIntegrationRoute is a [HandlerRoute] that represents a relationship
-	// between the [Application] and an [IntegrationMessageHandler].
+	// IntegrationHandlerRoute is a [HandlerRoute] that represents a
+	// relationship between the [Application] and an
+	// [IntegrationMessageHandler].
 	//
-	// Avoid constructing values of this type directly; use [ViaIntegration]
-	// instead.
-	ViaIntegrationRoute struct {
+	// Use [ViaIntegration] to construct values of this type.
+	IntegrationHandlerRoute struct {
 		nocmp
-		Handler IntegrationMessageHandler
+		handler IntegrationMessageHandler
 	}
 
-	// ViaProjectionRoute is a [HandlerRoute] that represents a relationship
+	// ProjectionHandlerRoute is a [HandlerRoute] that represents a relationship
 	// between the [Application] and a [ProjectionMessageHandler].
 	//
-	// Avoid constructing values of this type directly; use [ViaProjection]
-	// instead.
-	ViaProjectionRoute struct {
+	// Use [ViaProjection] to construct values of this type.
+	ProjectionHandlerRoute struct {
 		nocmp
-		Handler ProjectionMessageHandler
+		handler ProjectionMessageHandler
 	}
 )
 
@@ -117,26 +126,22 @@ type (
 	}
 )
 
-// HandlerRoutesBuilder is an interface for types that can build configuration
-// from [HandlerRoute] values.
-//
-// This type is part of the engine configuration API. It's not intended for
-// use during application development.
-type HandlerRoutesBuilder interface {
-	ViaAggregate(ViaAggregateRoute)
-	ViaProcess(ViaProcessRoute)
-	ViaIntegration(ViaIntegrationRoute)
-	ViaProjection(ViaProjectionRoute)
+// Handler returns the [AggregateMessageHandler] for r.
+func (r AggregateHandlerRoute) Handler() AggregateMessageHandler {
+	return r.handler
 }
 
-// ApplyHandlerRoute passes r to [HandlerRoutesBuilder].ViaAggregate.
-func (r ViaAggregateRoute) ApplyHandlerRoute(b HandlerRoutesBuilder) { b.ViaAggregate(r) }
+// Handler returns the [ProcessMessageHandler] for r.
+func (r ProcessHandlerRoute) Handler() ProcessMessageHandler {
+	return r.handler
+}
 
-// ApplyHandlerRoute passes r to [HandlerRoutesBuilder].ViaProcess.
-func (r ViaProcessRoute) ApplyHandlerRoute(b HandlerRoutesBuilder) { b.ViaProcess(r) }
+// Handler returns the [IntegrationMessageHandler] for r.
+func (r IntegrationHandlerRoute) Handler() IntegrationMessageHandler {
+	return r.handler
+}
 
-// ApplyHandlerRoute passes r to [HandlerRoutesBuilder].ViaIntegration.
-func (r ViaIntegrationRoute) ApplyHandlerRoute(b HandlerRoutesBuilder) { b.ViaIntegration(r) }
-
-// ApplyHandlerRoute passes r to [HandlerRoutesBuilder].ViaProjection.
-func (r ViaProjectionRoute) ApplyHandlerRoute(b HandlerRoutesBuilder) { b.ViaProjection(r) }
+// Handler returns the [ProjectionMessageHandler] for r.
+func (r ProjectionHandlerRoute) Handler() ProjectionMessageHandler {
+	return r.handler
+}

--- a/handlerroute_nocoverage.go
+++ b/handlerroute_nocoverage.go
@@ -1,0 +1,6 @@
+package dogma
+
+func (AggregateHandlerRoute) isHandlerRoute()   {}
+func (ProcessHandlerRoute) isHandlerRoute()     {}
+func (IntegrationHandlerRoute) isHandlerRoute() {}
+func (ProjectionHandlerRoute) isHandlerRoute()  {}

--- a/handlerroute_test.go
+++ b/handlerroute_test.go
@@ -6,66 +6,98 @@ import (
 	. "github.com/dogmatiq/dogma"
 )
 
-type handlerRoutesBuilder struct {
-	Aggregate   ViaAggregateRoute
-	Process     ViaProcessRoute
-	Integration ViaIntegrationRoute
-	Projection  ViaProjectionRoute
-}
-
-func (b *handlerRoutesBuilder) ViaAggregate(r ViaAggregateRoute)     { b.Aggregate = r }
-func (b *handlerRoutesBuilder) ViaProcess(r ViaProcessRoute)         { b.Process = r }
-func (b *handlerRoutesBuilder) ViaIntegration(r ViaIntegrationRoute) { b.Integration = r }
-func (b *handlerRoutesBuilder) ViaProjection(r ViaProjectionRoute)   { b.Projection = r }
-
 func TestViaAggregate(t *testing.T) {
-	type aggregate struct{ AggregateMessageHandler }
+	t.Run("it returns a route with the specified handler", func(t *testing.T) {
+		type aggregate struct{ AggregateMessageHandler }
 
-	b := &handlerRoutesBuilder{}
-	h := &aggregate{}
-	r := ViaAggregate(h)
-	r.ApplyHandlerRoute(b)
+		h := &aggregate{}
+		r := ViaAggregate(h)
+		x := expectType[AggregateHandlerRoute](t, r)
 
-	if b.Aggregate.Handler != h {
-		t.Fatal("unexpected handler")
-	}
+		if x.Handler() != h {
+			t.Fatal("unexpected handler")
+		}
+	})
+
+	t.Run("it panics if the handler is nil", func(t *testing.T) {
+		expectPanic(
+			t,
+			`handler cannot be nil`,
+			func() {
+				ViaAggregate(nil)
+			},
+		)
+	})
 }
 
 func TestViaProcess(t *testing.T) {
-	type process struct{ ProcessMessageHandler }
+	t.Run("it returns a route with the specified handler", func(t *testing.T) {
+		type process struct{ ProcessMessageHandler }
 
-	b := &handlerRoutesBuilder{}
-	h := &process{}
-	r := ViaProcess(h)
-	r.ApplyHandlerRoute(b)
+		h := &process{}
+		r := ViaProcess(h)
+		x := expectType[ProcessHandlerRoute](t, r)
 
-	if b.Process.Handler != h {
-		t.Fatal("unexpected handler")
-	}
+		if x.Handler() != h {
+			t.Fatal("unexpected handler")
+		}
+	})
+
+	t.Run("it panics if the handler is nil", func(t *testing.T) {
+		expectPanic(
+			t,
+			`handler cannot be nil`,
+			func() {
+				ViaProcess(nil)
+			},
+		)
+	})
 }
 
 func TestViaIntegration(t *testing.T) {
-	type integration struct{ IntegrationMessageHandler }
+	t.Run("it returns a route with the specified handler", func(t *testing.T) {
+		type integration struct{ IntegrationMessageHandler }
 
-	b := &handlerRoutesBuilder{}
-	h := &integration{}
-	r := ViaIntegration(h)
-	r.ApplyHandlerRoute(b)
+		h := &integration{}
+		r := ViaIntegration(h)
+		x := expectType[IntegrationHandlerRoute](t, r)
 
-	if b.Integration.Handler != h {
-		t.Fatal("unexpected handler")
-	}
+		if x.Handler() != h {
+			t.Fatal("unexpected handler")
+		}
+	})
+
+	t.Run("it panics if the handler is nil", func(t *testing.T) {
+		expectPanic(
+			t,
+			`handler cannot be nil`,
+			func() {
+				ViaIntegration(nil)
+			},
+		)
+	})
 }
 
 func TestViaProjection(t *testing.T) {
-	type projection struct{ ProjectionMessageHandler }
+	t.Run("it returns a route with the specified handler", func(t *testing.T) {
+		type projection struct{ ProjectionMessageHandler }
 
-	b := &handlerRoutesBuilder{}
-	h := &projection{}
-	r := ViaProjection(h)
-	r.ApplyHandlerRoute(b)
+		h := &projection{}
+		r := ViaProjection(h)
+		x := expectType[ProjectionHandlerRoute](t, r)
 
-	if b.Projection.Handler != h {
-		t.Fatal("unexpected handler")
-	}
+		if x.Handler() != h {
+			t.Fatal("unexpected handler")
+		}
+	})
+
+	t.Run("it panics if the handler is nil", func(t *testing.T) {
+		expectPanic(
+			t,
+			`handler cannot be nil`,
+			func() {
+				ViaProjection(nil)
+			},
+		)
+	})
 }

--- a/message_test.go
+++ b/message_test.go
@@ -1,0 +1,9 @@
+package dogma_test
+
+import (
+	. "github.com/dogmatiq/dogma"
+)
+
+func init() {
+	assertIsComparable(UnexpectedMessage)
+}

--- a/messageregistry.go
+++ b/messageregistry.go
@@ -74,7 +74,6 @@ type RegisterTimeoutOption interface {
 // to the registry.
 type RegisteredMessageType struct {
 	nocmp
-
 	id  string
 	typ reflect.Type
 	new func() Message

--- a/messageroute.go
+++ b/messageroute.go
@@ -9,8 +9,11 @@ package dogma
 // [IntegrationConfigurer].Routes.
 //
 // The engine panics if the application has multiple handlers that handle T.
-func HandlesCommand[T Command](...HandlesCommandOption) HandlesCommandRoute {
-	return HandlesCommandRoute{registeredMessageTypeFor[T]()}
+func HandlesCommand[T Command](...HandlesCommandOption) interface {
+	AggregateRoute
+	IntegrationRoute
+} {
+	return HandlesCommandRoute{typ: registeredMessageTypeFor[T]()}
 }
 
 // ExecutesCommand configures a [ProcessMessageHandler] as a producer of
@@ -21,8 +24,10 @@ func HandlesCommand[T Command](...HandlesCommandOption) HandlesCommandRoute {
 // Pass the returned [MessageRoute] to [ProcessConfigurer].Routes.
 //
 // The application may have multiple handlers that execute T.
-func ExecutesCommand[T Command](...ExecutesCommandOption) ExecutesCommandRoute {
-	return ExecutesCommandRoute{registeredMessageTypeFor[T]()}
+func ExecutesCommand[T Command](...ExecutesCommandOption) interface {
+	ProcessRoute
+} {
+	return ExecutesCommandRoute{typ: registeredMessageTypeFor[T]()}
 }
 
 // RecordsEvent configures an [AggregateMessageHandler] or
@@ -34,8 +39,11 @@ func ExecutesCommand[T Command](...ExecutesCommandOption) ExecutesCommandRoute {
 // [IntegrationConfigurer].Routes.
 //
 // The engine panics if the application has multiple handlers that record T.
-func RecordsEvent[T Event](...RecordsEventOption) RecordsEventRoute {
-	return RecordsEventRoute{registeredMessageTypeFor[T]()}
+func RecordsEvent[T Event](...RecordsEventOption) interface {
+	AggregateRoute
+	IntegrationRoute
+} {
+	return RecordsEventRoute{typ: registeredMessageTypeFor[T]()}
 }
 
 // HandlesEvent configures a [ProcessMessageHandler] or [ProjectionMessageHandler] as a
@@ -47,8 +55,11 @@ func RecordsEvent[T Event](...RecordsEventOption) RecordsEventRoute {
 // [ProjectionConfigurer].Routes.
 //
 // An application may have multiple handlers that handle T.
-func HandlesEvent[T Event](...HandlesEventOption) HandlesEventRoute {
-	return HandlesEventRoute{registeredMessageTypeFor[T]()}
+func HandlesEvent[T Event](...HandlesEventOption) interface {
+	ProcessRoute
+	ProjectionRoute
+} {
+	return HandlesEventRoute{typ: registeredMessageTypeFor[T]()}
 }
 
 // SchedulesTimeout configures a [ProcessMessageHandler] as a scheduler of
@@ -59,49 +70,64 @@ func HandlesEvent[T Event](...HandlesEventOption) HandlesEventRoute {
 // Pass the returned [MessageRoute] to [ProcessConfigurer].Routes.
 //
 // The application may have multiple handlers that schedule T.
-func SchedulesTimeout[T Timeout](...SchedulesTimeoutOption) SchedulesTimeoutRoute {
-	return SchedulesTimeoutRoute{registeredMessageTypeFor[T]()}
+func SchedulesTimeout[T Timeout](...SchedulesTimeoutOption) interface {
+	ProcessRoute
+} {
+	return SchedulesTimeoutRoute{typ: registeredMessageTypeFor[T]()}
 }
 
 type (
 	// MessageRoute is an interface for types that describe a relationship between a
 	// message handler and a specific message type.
-	MessageRoute interface{ isMessageRoute() }
+	MessageRoute interface {
+		isMessageRoute()
+		Type() RegisteredMessageType
+	}
 
 	// HandlesCommandRoute is a [HandlerRoute] that represents a handler's
 	// ability to handle [Command] messages of a specific type.
 	//
-	// Avoid constructing values of this type directly; use [HandlesCommand]
-	// instead.
-	HandlesCommandRoute struct{ Type RegisteredMessageType }
+	// Use [HandlesCommand] to construct values of this type.
+	HandlesCommandRoute struct {
+		nocmp
+		typ RegisteredMessageType
+	}
 
 	// ExecutesCommandRoute is a [HandlerRoute] that represents a handler's
 	// ability to execute [Command] messages of a specific type.
 	//
-	// Avoid constructing values of this type directly; use [ExecutesCommand]
-	// instead.
-	ExecutesCommandRoute struct{ Type RegisteredMessageType }
+	// Use [ExecutesCommand] to construct values of this type.
+	ExecutesCommandRoute struct {
+		nocmp
+		typ RegisteredMessageType
+	}
 
 	// HandlesEventRoute is a [HandlerRoute] that represents a handler's
 	// ability to handle [Event] messages of a specific type.
 	//
-	// Avoid constructing values of this type directly; use [HandlesEvent]
-	// instead.
-	HandlesEventRoute struct{ Type RegisteredMessageType }
+	// Use [HandlesEvent] to construct values of this type.
+	HandlesEventRoute struct {
+		nocmp
+		typ RegisteredMessageType
+	}
 
 	// RecordsEventRoute is a [HandlerRoute] that represents a handler's
 	// ability to record [Event] messages of a specific type.
 	//
-	// Avoid constructing values of this type directly; use [RecordsEvent]
-	// instead.
-	RecordsEventRoute struct{ Type RegisteredMessageType }
+	// Use [RecordsEvent] to construct values of this type.
+	RecordsEventRoute struct {
+		nocmp
+		typ RegisteredMessageType
+	}
 
 	// SchedulesTimeoutRoute is a [HandlerRoute] that represents a handler's
 	// ability to schedule [Timeout] messages of a specific type.
 	//
-	// Avoid constructing values of this type directly; use [SchedulesTimeout]
-	// instead.
-	SchedulesTimeoutRoute struct{ Type RegisteredMessageType }
+	// Use [SchedulesTimeout] to construct values of this type.
+	SchedulesTimeoutRoute struct {
+		nocmp
+		typ RegisteredMessageType
+	}
 )
 
 type (
@@ -145,3 +171,28 @@ type (
 		futureSchedulesTimeoutOption()
 	}
 )
+
+// Type returns the [RegisteredMessageType] for r.
+func (r HandlesCommandRoute) Type() RegisteredMessageType {
+	return r.typ
+}
+
+// Type returns the [RegisteredMessageType] for r.
+func (r ExecutesCommandRoute) Type() RegisteredMessageType {
+	return r.typ
+}
+
+// Type returns the [RegisteredMessageType] for r.
+func (r HandlesEventRoute) Type() RegisteredMessageType {
+	return r.typ
+}
+
+// Type returns the [RegisteredMessageType] for r.
+func (r RecordsEventRoute) Type() RegisteredMessageType {
+	return r.typ
+}
+
+// Type returns the [RegisteredMessageType] for r.
+func (r SchedulesTimeoutRoute) Type() RegisteredMessageType {
+	return r.typ
+}

--- a/messageroute_test.go
+++ b/messageroute_test.go
@@ -12,9 +12,10 @@ func TestHandlesCommand(t *testing.T) {
 		type T struct{ Command }
 		RegisterCommand[T]("83c4a2d9-a728-49e6-83a3-6c670b99a173")
 
-		route := HandlesCommand[T]()
+		r := HandlesCommand[T]()
+		expectType[HandlesCommandRoute](t, r)
 
-		got := route.Type.GoType()
+		got := r.Type().GoType()
 		want := reflect.TypeFor[T]()
 
 		if got != want {
@@ -39,9 +40,10 @@ func TestExecutesCommand(t *testing.T) {
 		type T struct{ Command }
 		RegisterCommand[T]("7b8cf1fd-722e-4337-bc5c-9ce4f32ab9d4")
 
-		route := ExecutesCommand[T]()
+		r := ExecutesCommand[T]()
+		expectType[ExecutesCommandRoute](t, r)
 
-		got := route.Type.GoType()
+		got := r.Type().GoType()
 		want := reflect.TypeFor[T]()
 
 		if got != want {
@@ -66,9 +68,10 @@ func TestHandlesEvent(t *testing.T) {
 		type T struct{ Event }
 		RegisterEvent[T]("bef3014a-fca1-4cb3-90a3-ee83f5ca56c8")
 
-		route := HandlesEvent[T]()
+		r := HandlesEvent[T]()
+		expectType[HandlesEventRoute](t, r)
 
-		got := route.Type.GoType()
+		got := r.Type().GoType()
 		want := reflect.TypeFor[T]()
 
 		if got != want {
@@ -93,9 +96,10 @@ func TestRecordsEvent(t *testing.T) {
 		type T struct{ Event }
 		RegisterEvent[T]("19d21601-7d10-4aaa-85b5-248cf873b3d3")
 
-		route := RecordsEvent[T]()
+		r := RecordsEvent[T]()
+		expectType[RecordsEventRoute](t, r)
 
-		got := route.Type.GoType()
+		got := r.Type().GoType()
 		want := reflect.TypeFor[T]()
 
 		if got != want {
@@ -120,9 +124,10 @@ func TestSchedulesTimeout(t *testing.T) {
 		type T struct{ Timeout }
 		RegisterTimeout[T]("e11b5a92-e1ab-4a16-841a-9286b4e4d12f")
 
-		route := SchedulesTimeout[T]()
+		r := SchedulesTimeout[T]()
+		expectType[SchedulesTimeoutRoute](t, r)
 
-		got := route.Type.GoType()
+		got := r.Type().GoType()
 		want := reflect.TypeFor[T]()
 
 		if got != want {

--- a/process_test.go
+++ b/process_test.go
@@ -21,13 +21,16 @@ func TestNoTimeoutMessagesBehavior_HandleTimeout_Panics(t *testing.T) {
 	var v NoTimeoutMessagesBehavior
 	ctx := context.Background()
 
-	defer func() {
-		r := recover()
+	expectPanic(
+		t,
+		UnexpectedMessage,
+		func() {
+			v.HandleTimeout(ctx, nil, nil, nil)
+		},
+	)
+}
 
-		if r != UnexpectedMessage {
-			t.Fatal("expected panic did not occur")
-		}
-	}()
-
-	v.HandleTimeout(ctx, nil, nil, nil)
+func init() {
+	assertIsComparable(StatelessProcessBehavior{})
+	assertIsComparable(NoTimeoutMessagesBehavior{})
 }

--- a/projection_test.go
+++ b/projection_test.go
@@ -16,3 +16,7 @@ func TestNoCompactBehavior_Compact_ReturnsNil(t *testing.T) {
 		t.Fatal("unexpected error returned")
 	}
 }
+
+func init() {
+	assertIsComparable(NoCompactBehavior{})
+}

--- a/util_test.go
+++ b/util_test.go
@@ -1,6 +1,7 @@
 package dogma_test
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -17,7 +18,7 @@ func (*messageWithPointerReceivers[S]) Validate(S) error           { panic("not 
 
 // expectPanic is a test helper that asserts that fn panics with a specific
 // message.
-func expectPanic(t *testing.T, message string, fn func()) {
+func expectPanic[T comparable](t *testing.T, message T, fn func()) {
 	t.Helper()
 
 	defer func() {
@@ -31,10 +32,25 @@ func expectPanic(t *testing.T, message string, fn func()) {
 				"unexpected panic message:\n  got %q (%T),\n want %q",
 				got,
 				got,
-				message,
+				fmt.Sprintf("%v", message),
 			)
 		}
 	}()
 
 	fn()
 }
+
+func expectType[T any](t *testing.T, v any) T {
+	t.Helper()
+
+	got, ok := v.(T)
+
+	if !ok {
+		var want T
+		t.Fatalf("unexpected type: got %T, want %T", got, want)
+	}
+
+	return got
+}
+
+func assertIsComparable[T comparable](T) {}


### PR DESCRIPTION
- Replace builder pattern with direct value types for ExecuteCommandOption and HandlerRoute
- Rename ViaXxxRoute types to XxxHandlerRoute for consistency
- Add nil handler validation to Via functions
- Expose Handler() methods on route types instead of public fields
- Update option types to use nocmp and dedicated methods
- Improve test coverage for nil handler cases and error conditions

