### PR TITLE
Add marshaling methods to message interface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ The format is based on [Keep a Changelog], and this project adheres to
 [bc]: https://github.com/dogmatiq/.github/blob/main/VERSIONING.md#changelogs
 [engine bc]: https://github.com/dogmatiq/.github/blob/main/VERSIONING.md#changelogs
 
+## [Unreleased]
+
+### Added
+
+- **[BC]** Added `Message.MarshalBinary()` and `UnmarshalBinary()` methods.
+
+### Changed
+
+- **[BC]** Implementations of `Message` must now be implemented using pointer
+  receivers, as this is the only implementation pattern that makes sense with
+  the addition of the `Message.UnmarshalBinary()` method. Accordingly,
+  `RegisterCommand()`, `RegisterEvent()` and `RegisterTimeout()` now require a
+  type parameter that is a pointer.
+
 ## [0.16.0] - 2025-09-14
 
 This release changes how handlers are added to an application. It introduces the

--- a/message.go
+++ b/message.go
@@ -36,6 +36,13 @@ type Message interface {
 	// relevant to [Event] messages, where each type should represent a specific
 	// state change regardless of who initiated it.
 	MessageDescription() string
+
+	// MarshalBinary returns the message's binary representation, suitable for
+	// persistence or transmission over the network.
+	MarshalBinary() ([]byte, error)
+
+	// UnmarshalBinary decodes a message from its binary representation.
+	UnmarshalBinary([]byte) error
 }
 
 // UnexpectedMessage is a panic value used by a message handler when it receives

--- a/messageroute_test.go
+++ b/messageroute_test.go
@@ -10,13 +10,13 @@ import (
 func TestHandlesCommand(t *testing.T) {
 	t.Run("it returns a route containing the registered message type", func(t *testing.T) {
 		type T struct{ Command }
-		RegisterCommand[T]("83c4a2d9-a728-49e6-83a3-6c670b99a173")
+		RegisterCommand[*T]("83c4a2d9-a728-49e6-83a3-6c670b99a173")
 
-		r := HandlesCommand[T]()
+		r := HandlesCommand[*T]()
 		expectType[HandlesCommandRoute](t, r)
 
 		got := r.Type().GoType()
-		want := reflect.TypeFor[T]()
+		want := reflect.TypeFor[*T]()
 
 		if got != want {
 			t.Fatalf("unexpected message type: got %s, want %s", got, want)
@@ -26,10 +26,10 @@ func TestHandlesCommand(t *testing.T) {
 	t.Run("it panics if the type is not in the registry", func(t *testing.T) {
 		expectPanic(
 			t,
-			"github.com/dogmatiq/dogma_test.T is not in the message type registry",
+			"*github.com/dogmatiq/dogma_test.T is not in the message type registry",
 			func() {
 				type T struct{ Command }
-				HandlesCommand[T]()
+				HandlesCommand[*T]()
 			},
 		)
 	})
@@ -38,13 +38,13 @@ func TestHandlesCommand(t *testing.T) {
 func TestExecutesCommand(t *testing.T) {
 	t.Run("it returns a route containing the registered message type", func(t *testing.T) {
 		type T struct{ Command }
-		RegisterCommand[T]("7b8cf1fd-722e-4337-bc5c-9ce4f32ab9d4")
+		RegisterCommand[*T]("7b8cf1fd-722e-4337-bc5c-9ce4f32ab9d4")
 
-		r := ExecutesCommand[T]()
+		r := ExecutesCommand[*T]()
 		expectType[ExecutesCommandRoute](t, r)
 
 		got := r.Type().GoType()
-		want := reflect.TypeFor[T]()
+		want := reflect.TypeFor[*T]()
 
 		if got != want {
 			t.Fatalf("unexpected message type: got %s, want %s", got, want)
@@ -54,10 +54,10 @@ func TestExecutesCommand(t *testing.T) {
 	t.Run("it panics if the type is not in the registry", func(t *testing.T) {
 		expectPanic(
 			t,
-			"github.com/dogmatiq/dogma_test.T is not in the message type registry",
+			"*github.com/dogmatiq/dogma_test.T is not in the message type registry",
 			func() {
 				type T struct{ Command }
-				ExecutesCommand[T]()
+				ExecutesCommand[*T]()
 			},
 		)
 	})
@@ -66,13 +66,13 @@ func TestExecutesCommand(t *testing.T) {
 func TestHandlesEvent(t *testing.T) {
 	t.Run("it returns a route containing the registered message type", func(t *testing.T) {
 		type T struct{ Event }
-		RegisterEvent[T]("bef3014a-fca1-4cb3-90a3-ee83f5ca56c8")
+		RegisterEvent[*T]("bef3014a-fca1-4cb3-90a3-ee83f5ca56c8")
 
-		r := HandlesEvent[T]()
+		r := HandlesEvent[*T]()
 		expectType[HandlesEventRoute](t, r)
 
 		got := r.Type().GoType()
-		want := reflect.TypeFor[T]()
+		want := reflect.TypeFor[*T]()
 
 		if got != want {
 			t.Fatalf("unexpected message type: got %s, want %s", got, want)
@@ -94,13 +94,13 @@ func TestHandlesEvent(t *testing.T) {
 func TestRecordsEvent(t *testing.T) {
 	t.Run("it returns a route containing the registered message type", func(t *testing.T) {
 		type T struct{ Event }
-		RegisterEvent[T]("19d21601-7d10-4aaa-85b5-248cf873b3d3")
+		RegisterEvent[*T]("19d21601-7d10-4aaa-85b5-248cf873b3d3")
 
-		r := RecordsEvent[T]()
+		r := RecordsEvent[*T]()
 		expectType[RecordsEventRoute](t, r)
 
 		got := r.Type().GoType()
-		want := reflect.TypeFor[T]()
+		want := reflect.TypeFor[*T]()
 
 		if got != want {
 			t.Fatalf("unexpected message type: got %s, want %s", got, want)
@@ -110,10 +110,10 @@ func TestRecordsEvent(t *testing.T) {
 	t.Run("it panics if the type is not in the registry", func(t *testing.T) {
 		expectPanic(
 			t,
-			"github.com/dogmatiq/dogma_test.T is not in the message type registry",
+			"*github.com/dogmatiq/dogma_test.T is not in the message type registry",
 			func() {
 				type T struct{ Event }
-				RecordsEvent[T]()
+				RecordsEvent[*T]()
 			},
 		)
 	})
@@ -122,13 +122,13 @@ func TestRecordsEvent(t *testing.T) {
 func TestSchedulesTimeout(t *testing.T) {
 	t.Run("it returns a route containing the registered message type", func(t *testing.T) {
 		type T struct{ Timeout }
-		RegisterTimeout[T]("e11b5a92-e1ab-4a16-841a-9286b4e4d12f")
+		RegisterTimeout[*T]("e11b5a92-e1ab-4a16-841a-9286b4e4d12f")
 
-		r := SchedulesTimeout[T]()
+		r := SchedulesTimeout[*T]()
 		expectType[SchedulesTimeoutRoute](t, r)
 
 		got := r.Type().GoType()
-		want := reflect.TypeFor[T]()
+		want := reflect.TypeFor[*T]()
 
 		if got != want {
 			t.Fatalf("unexpected message type: got %s, want %s", got, want)
@@ -138,10 +138,10 @@ func TestSchedulesTimeout(t *testing.T) {
 	t.Run("it panics if the type is not in the registry", func(t *testing.T) {
 		expectPanic(
 			t,
-			"github.com/dogmatiq/dogma_test.T is not in the message type registry",
+			"*github.com/dogmatiq/dogma_test.T is not in the message type registry",
 			func() {
 				type T struct{ Timeout }
-				SchedulesTimeout[T]()
+				SchedulesTimeout[*T]()
 			},
 		)
 	})

--- a/messagetyperegistry_test.go
+++ b/messagetyperegistry_test.go
@@ -11,14 +11,14 @@ import (
 func TestRegisteredMessageTypeFor(t *testing.T) {
 	t.Run("it returns the type that represents T", func(t *testing.T) {
 		type T struct{ Command }
-		RegisterCommand[T]("2d8ce56f-1983-44e3-a55d-f74d8dcb0adc")
+		RegisterCommand[*T]("2d8ce56f-1983-44e3-a55d-f74d8dcb0adc")
 
-		mt, ok := RegisteredMessageTypeFor[T]()
+		mt, ok := RegisteredMessageTypeFor[*T]()
 		if !ok {
 			t.Fatal("expected message type to be registered")
 		}
 
-		if got, want := mt.GoType(), reflect.TypeFor[T](); got != want {
+		if got, want := mt.GoType(), reflect.TypeFor[*T](); got != want {
 			t.Fatalf("unexpected type: got %v, want %v", got, want)
 		}
 	})
@@ -26,7 +26,7 @@ func TestRegisteredMessageTypeFor(t *testing.T) {
 	t.Run("it returns false when T is not in the registry", func(t *testing.T) {
 		type T struct{ Command }
 
-		_, ok := RegisteredMessageTypeFor[T]()
+		_, ok := RegisteredMessageTypeFor[*T]()
 		if ok {
 			t.Fatal("did not expect message type to be registered")
 		}
@@ -37,14 +37,14 @@ func TestRegisteredMessageTypeByID(t *testing.T) {
 	t.Run("it returns the type associated with the normalized ID", func(t *testing.T) {
 		const id = "37264B0D-4342-4708-8263-60D82DE78AD1"
 		type T struct{ Event }
-		RegisterEvent[T](id)
+		RegisterEvent[*T](id)
 
 		mt, ok := RegisteredMessageTypeByID(id)
 		if !ok {
 			t.Fatal("expected message type to be registered")
 		}
 
-		if got, want := mt.GoType(), reflect.TypeOf(T{}); got != want {
+		if got, want := mt.GoType(), reflect.TypeFor[*T](); got != want {
 			t.Fatalf("unexpected type: got %v, want %v", got, want)
 		}
 	})
@@ -73,19 +73,19 @@ func TestRegisteredMessageTypes(t *testing.T) {
 		type U struct{ Event }
 		type V struct{ Timeout }
 
-		RegisterCommand[T]("b3160ff8-f19a-4f79-b81c-0551c99aeac2")
-		RegisterEvent[U]("c3f856ba-0519-4335-ad84-313aa0fedc5e")
-		RegisterTimeout[V]("8ab13db4-33ff-4dde-862c-7c94a0477231")
+		RegisterCommand[*T]("b3160ff8-f19a-4f79-b81c-0551c99aeac2")
+		RegisterEvent[*U]("c3f856ba-0519-4335-ad84-313aa0fedc5e")
+		RegisterTimeout[*V]("8ab13db4-33ff-4dde-862c-7c94a0477231")
 
 		var yieldedT, yieldedU, yieldedV bool
 
 		for mt := range RegisteredMessageTypes() {
 			switch mt.GoType() {
-			case reflect.TypeFor[T]():
+			case reflect.TypeFor[*T]():
 				yieldedT = true
-			case reflect.TypeFor[U]():
+			case reflect.TypeFor[*U]():
 				yieldedU = true
-			case reflect.TypeFor[V]():
+			case reflect.TypeFor[*V]():
 				yieldedV = true
 			}
 		}
@@ -105,7 +105,7 @@ func TestRegisteredMessageTypes(t *testing.T) {
 
 	t.Run("break early (coverage)", func(t *testing.T) {
 		type T struct{ Command }
-		RegisterCommand[T]("b61a3911-f987-476d-973c-16c343a59a17")
+		RegisterCommand[*T]("b61a3911-f987-476d-973c-16c343a59a17")
 
 		for range RegisteredMessageTypes() {
 			break
@@ -117,9 +117,9 @@ func TestMessageTypeRegistration(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		const id = "476497D0-2132-4EC5-90D4-21E2B6E6EB54"
 		type T struct{ Command }
-		RegisterCommand[T](id)
+		RegisterCommand[*T](id)
 
-		mt, ok := RegisteredMessageTypeFor[T]()
+		mt, ok := RegisteredMessageTypeFor[*T]()
 		if !ok {
 			t.Fatal("message type is not registered")
 		}
@@ -143,122 +143,86 @@ func TestMessageTypeRegistration(t *testing.T) {
 		}{
 			{
 				"duplicate registration",
-				`cannot register github.com/dogmatiq/dogma_test.T: it is already registered`,
+				`cannot register *github.com/dogmatiq/dogma_test.T: it is already registered`,
 				func() {
 					type T struct{ Command }
-					RegisterCommand[T]("658e7da4-ffa9-4d11-b796-29346ec6f586")
-					RegisterCommand[T]("658e7da4-ffa9-4d11-b796-29346ec6f586")
+					RegisterCommand[*T]("658e7da4-ffa9-4d11-b796-29346ec6f586")
+					RegisterCommand[*T]("658e7da4-ffa9-4d11-b796-29346ec6f586")
 				},
-				`cannot register github.com/dogmatiq/dogma_test.T: it is already registered`,
+				`cannot register *github.com/dogmatiq/dogma_test.T: it is already registered`,
 				func() {
 					type T struct{ Event }
-					RegisterEvent[T]("746979d2-2ce3-4b2f-a4d0-d34b069ba31b")
-					RegisterEvent[T]("746979d2-2ce3-4b2f-a4d0-d34b069ba31b")
+					RegisterEvent[*T]("746979d2-2ce3-4b2f-a4d0-d34b069ba31b")
+					RegisterEvent[*T]("746979d2-2ce3-4b2f-a4d0-d34b069ba31b")
 				},
-				`cannot register github.com/dogmatiq/dogma_test.T: it is already registered`,
+				`cannot register *github.com/dogmatiq/dogma_test.T: it is already registered`,
 				func() {
 					type T struct{ Timeout }
-					RegisterTimeout[T]("6dfb9656-92b4-4cef-b51d-f808bf6403b2")
-					RegisterTimeout[T]("6dfb9656-92b4-4cef-b51d-f808bf6403b2")
+					RegisterTimeout[*T]("6dfb9656-92b4-4cef-b51d-f808bf6403b2")
+					RegisterTimeout[*T]("6dfb9656-92b4-4cef-b51d-f808bf6403b2")
 				},
 			},
 			{
 				"conflicting registration (same type)",
-				`cannot register github.com/dogmatiq/dogma_test.T: it is already registered as "f2a5c633-fbc1-4230-937d-057e3d141d4f"`,
+				`cannot register *github.com/dogmatiq/dogma_test.T: it is already registered as "f2a5c633-fbc1-4230-937d-057e3d141d4f"`,
 				func() {
 					type T struct{ Command }
-					RegisterCommand[T]("f2a5c633-fbc1-4230-937d-057e3d141d4f")
-					RegisterCommand[T]("6b529039-03fe-4fde-8986-42892f39d93e")
+					RegisterCommand[*T]("f2a5c633-fbc1-4230-937d-057e3d141d4f")
+					RegisterCommand[*T]("6b529039-03fe-4fde-8986-42892f39d93e")
 				},
-				`cannot register github.com/dogmatiq/dogma_test.T: it is already registered as "cf7a6893-da73-4638-9438-c59d32b2e087"`,
+				`cannot register *github.com/dogmatiq/dogma_test.T: it is already registered as "cf7a6893-da73-4638-9438-c59d32b2e087"`,
 				func() {
 					type T struct{ Event }
-					RegisterEvent[T]("cf7a6893-da73-4638-9438-c59d32b2e087")
-					RegisterEvent[T]("ffd82f55-a6e3-4c02-b43c-491a5abc1b46")
+					RegisterEvent[*T]("cf7a6893-da73-4638-9438-c59d32b2e087")
+					RegisterEvent[*T]("ffd82f55-a6e3-4c02-b43c-491a5abc1b46")
 				},
-				`cannot register github.com/dogmatiq/dogma_test.T: it is already registered as "2e4c3894-f76b-4ccb-a817-4422df36138e"`,
+				`cannot register *github.com/dogmatiq/dogma_test.T: it is already registered as "2e4c3894-f76b-4ccb-a817-4422df36138e"`,
 				func() {
 					type T struct{ Timeout }
-					RegisterTimeout[T]("2e4c3894-f76b-4ccb-a817-4422df36138e")
-					RegisterTimeout[T]("3de60928-e9be-4a62-9fd8-60734f53cde5")
+					RegisterTimeout[*T]("2e4c3894-f76b-4ccb-a817-4422df36138e")
+					RegisterTimeout[*T]("3de60928-e9be-4a62-9fd8-60734f53cde5")
 				},
 			},
 			{
 				"conflicting registration (same ID)",
-				`cannot register github.com/dogmatiq/dogma_test.U: "b8a9ee69-e6f4-41ae-8fba-524505a2aaba" is already associated with github.com/dogmatiq/dogma_test.T`,
+				`cannot register *github.com/dogmatiq/dogma_test.U: "b8a9ee69-e6f4-41ae-8fba-524505a2aaba" is already associated with *github.com/dogmatiq/dogma_test.T`,
 				func() {
 					type T struct{ Command }
 					type U struct{ Command }
-					RegisterCommand[T]("b8a9ee69-e6f4-41ae-8fba-524505a2aaba")
-					RegisterCommand[U]("b8a9ee69-e6f4-41ae-8fba-524505a2aaba")
+					RegisterCommand[*T]("b8a9ee69-e6f4-41ae-8fba-524505a2aaba")
+					RegisterCommand[*U]("b8a9ee69-e6f4-41ae-8fba-524505a2aaba")
 				},
-				`cannot register github.com/dogmatiq/dogma_test.U: "21b3ca92-2667-4f0e-b175-7f30f015f968" is already associated with github.com/dogmatiq/dogma_test.T`,
+				`cannot register *github.com/dogmatiq/dogma_test.U: "21b3ca92-2667-4f0e-b175-7f30f015f968" is already associated with *github.com/dogmatiq/dogma_test.T`,
 				func() {
 					type T struct{ Event }
 					type U struct{ Event }
-					RegisterEvent[T]("21b3ca92-2667-4f0e-b175-7f30f015f968")
-					RegisterEvent[U]("21b3ca92-2667-4f0e-b175-7f30f015f968")
+					RegisterEvent[*T]("21b3ca92-2667-4f0e-b175-7f30f015f968")
+					RegisterEvent[*U]("21b3ca92-2667-4f0e-b175-7f30f015f968")
 				},
-				`cannot register github.com/dogmatiq/dogma_test.U: "66c69a42-ea81-4ca9-8587-bf88e8abaf34" is already associated with github.com/dogmatiq/dogma_test.T`,
+				`cannot register *github.com/dogmatiq/dogma_test.U: "66c69a42-ea81-4ca9-8587-bf88e8abaf34" is already associated with *github.com/dogmatiq/dogma_test.T`,
 				func() {
 					type T struct{ Timeout }
 					type U struct{ Timeout }
-					RegisterTimeout[T]("66c69a42-ea81-4ca9-8587-bf88e8abaf34")
-					RegisterTimeout[U]("66c69a42-ea81-4ca9-8587-bf88e8abaf34")
-				},
-			},
-			{
-				"interface type",
-				`cannot register github.com/dogmatiq/dogma_test.T: message type is an interface, expected a concrete type`,
-				func() {
-					type T interface{ Command }
-					RegisterCommand[T]("4a43823c-66b7-43d5-a3ac-e7247c83ddd0")
-				},
-				`cannot register github.com/dogmatiq/dogma_test.T: message type is an interface, expected a concrete type`,
-				func() {
-					type T interface{ Event }
-					RegisterEvent[T]("2d5b4609-825d-45be-ac69-23a9dcbf1bff")
-				},
-				`cannot register github.com/dogmatiq/dogma_test.T: message type is an interface, expected a concrete type`,
-				func() {
-					type T interface{ Timeout }
-					RegisterTimeout[T]("07799033-587c-4e5f-bc3d-7ad1797e7ff6")
+					RegisterTimeout[*T]("66c69a42-ea81-4ca9-8587-bf88e8abaf34")
+					RegisterTimeout[*U]("66c69a42-ea81-4ca9-8587-bf88e8abaf34")
 				},
 			},
 			{
 				"invalid UUID",
-				`cannot register github.com/dogmatiq/dogma_test.T: "<non-uuid>" is not a canonical RFC 9562 UUID: expected 36 characters`,
+				`cannot register *github.com/dogmatiq/dogma_test.T: "<non-uuid>" is not a canonical RFC 9562 UUID: expected 36 characters`,
 				func() {
 					type T struct{ Command }
-					RegisterCommand[T]("<non-uuid>")
+					RegisterCommand[*T]("<non-uuid>")
 				},
-				`cannot register github.com/dogmatiq/dogma_test.T: "<non-uuid>" is not a canonical RFC 9562 UUID: expected 36 characters`,
+				`cannot register *github.com/dogmatiq/dogma_test.T: "<non-uuid>" is not a canonical RFC 9562 UUID: expected 36 characters`,
 				func() {
 					type T struct{ Event }
-					RegisterEvent[T]("<non-uuid>")
+					RegisterEvent[*T]("<non-uuid>")
 				},
-				`cannot register github.com/dogmatiq/dogma_test.T: "<non-uuid>" is not a canonical RFC 9562 UUID: expected 36 characters`,
+				`cannot register *github.com/dogmatiq/dogma_test.T: "<non-uuid>" is not a canonical RFC 9562 UUID: expected 36 characters`,
 				func() {
 					type T struct{ Timeout }
-					RegisterTimeout[T]("<non-uuid>")
-				},
-			},
-			{
-				"pointer to type that uses non-pointer receivers",
-				`cannot register *github.com/dogmatiq/dogma_test.T: message type uses non-pointer receivers, use github.com/dogmatiq/dogma_test.T (non-pointer) instead`,
-				func() {
-					type T struct{ Command }
-					RegisterCommand[*T]("fda0112d-29ce-4533-b03f-5b9dcfc3907a")
-				},
-				`cannot register *github.com/dogmatiq/dogma_test.T: message type uses non-pointer receivers, use github.com/dogmatiq/dogma_test.T (non-pointer) instead`,
-				func() {
-					type T struct{ Event }
-					RegisterEvent[*T]("5dad0988-498e-47e1-989e-b3014612c9d1")
-				},
-				`cannot register *github.com/dogmatiq/dogma_test.T: message type uses non-pointer receivers, use github.com/dogmatiq/dogma_test.T (non-pointer) instead`,
-				func() {
-					type T struct{ Timeout }
-					RegisterTimeout[*T]("b94ffd35-3434-4412-b46c-3ace7235595b")
+					RegisterTimeout[*T]("<non-uuid>")
 				},
 			},
 		}
@@ -286,9 +250,9 @@ func TestRegisteredMessageType(t *testing.T) {
 		t.Run("returns the normalized UUID", func(t *testing.T) {
 			const id = "5211A466-010A-4C89-BF36-9A95896BFE2B"
 			type T struct{ Command }
-			RegisterCommand[T](id)
+			RegisterCommand[*T](id)
 
-			mt, ok := RegisteredMessageTypeFor[T]()
+			mt, ok := RegisteredMessageTypeFor[*T]()
 			if !ok {
 				t.Fatal("message type is not registered")
 			}
@@ -302,15 +266,15 @@ func TestRegisteredMessageType(t *testing.T) {
 	t.Run("func GoType()", func(t *testing.T) {
 		t.Run("returns the reflect.Type of the message type", func(t *testing.T) {
 			type T struct{ Command }
-			RegisterCommand[T]("c1d2e3f4-5678-90ab-cdef-1234567890ab")
+			RegisterCommand[*T]("c1d2e3f4-5678-90ab-cdef-1234567890ab")
 
-			mt, ok := RegisteredMessageTypeFor[T]()
+			mt, ok := RegisteredMessageTypeFor[*T]()
 			if !ok {
 				t.Fatal("message type is not registered")
 			}
 
 			got := mt.GoType()
-			want := reflect.TypeFor[T]()
+			want := reflect.TypeFor[*T]()
 
 			if got != want {
 				t.Fatalf("unexpected message type: got %s, want %s", got, want)
@@ -319,56 +283,29 @@ func TestRegisteredMessageType(t *testing.T) {
 	})
 
 	t.Run("func New()", func(t *testing.T) {
-		t.Run("when the type uses non-pointer receivers", func(t *testing.T) {
-			type T struct{ Command }
-			RegisterCommand[T]("7c5724b3-bce9-413a-9777-94eff973539d")
+		type T struct{ Command }
+		RegisterCommand[*T]("7da02018-2a02-44ec-aa1f-b68d66d4887d")
 
-			mt, ok := RegisteredMessageTypeFor[T]()
+		mt, ok := RegisteredMessageTypeFor[*T]()
+		if !ok {
+			t.Fatal("message type is not registered")
+		}
+
+		t.Run("it returns a pointer to a zero-value", func(t *testing.T) {
+			m := mt.New()
+
+			p, ok := m.(*T)
 			if !ok {
-				t.Fatal("message type is not registered")
+				t.Fatalf("unexpected type: got %T, want %T", m, (*T)(nil))
 			}
 
-			t.Run("it returns a zero-value", func(t *testing.T) {
-				m := mt.New()
-
-				if _, ok := m.(T); !ok {
-					t.Fatalf("unexpected type: got %T, want %T", m, T{})
-				}
-
-				if v := reflect.ValueOf(m); !v.IsZero() {
-					t.Fatalf("expected zero-value message, got %v", v)
-				}
-			})
-		})
-
-		t.Run("when the type uses pointer receivers", func(t *testing.T) {
-			type T struct {
-				messageWithPointerReceivers[CommandValidationScope]
+			if p == nil {
+				t.Fatal("expected non-nil pointer")
 			}
 
-			RegisterCommand[*T]("7da02018-2a02-44ec-aa1f-b68d66d4887d")
-
-			mt, ok := RegisteredMessageTypeFor[*T]()
-			if !ok {
-				t.Fatal("message type is not registered")
+			if v := reflect.ValueOf(*p); !v.IsZero() {
+				t.Fatalf("expected pointer to zero-value message: got %v", v)
 			}
-
-			t.Run("it returns a pointer to a zero-value", func(t *testing.T) {
-				m := mt.New()
-
-				p, ok := m.(*T)
-				if !ok {
-					t.Fatalf("unexpected type: got %T, want %T", m, (*T)(nil))
-				}
-
-				if p == nil {
-					t.Fatal("expected non-nil pointer")
-				}
-
-				if v := reflect.ValueOf(*p); !v.IsZero() {
-					t.Fatalf("expected pointer to zero-value message: got %v", v)
-				}
-			})
 		})
 	})
 }

--- a/util_test.go
+++ b/util_test.go
@@ -5,17 +5,6 @@ import (
 	"testing"
 )
 
-// messageWithPointerReceivers is an implementation of [Message] that uses
-// pointer receivers.
-//
-// S is the validation scope type accepted by the Validate() method, which lets
-// the implementation match any of the [Command], [Event], or [Timeout]
-// interfaces as required.
-type messageWithPointerReceivers[S any] struct{}
-
-func (*messageWithPointerReceivers[S]) MessageDescription() string { panic("not implemented") }
-func (*messageWithPointerReceivers[S]) Validate(S) error           { panic("not implemented") }
-
 // expectPanic is a test helper that asserts that fn panics with a specific
 // message.
 func expectPanic[T comparable](t *testing.T, message T, fn func()) {


### PR DESCRIPTION
This PR adds a "self marshalling" requirement to message implementations, via new `MarshalBinary` and `UnmarshalBinary` methods. Partially addresses #176.

