### PR TITLE
Self-marshaling aggregate and process roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Added
 
 - **[BC]** Added `Message.MarshalBinary()` and `UnmarshalBinary()` methods.
+- **[BC]** Added `AggregateRoot.MarshalBinary()` and `UnmarshalBinary()` methods.
+- **[BC]** Added `ProcessRoot.MarshalBinary()` and `UnmarshalBinary()` methods.
+- Added `ErrNotSupported` to indicate that a feature is not supported. It is
+  currently allowed to be returned by the `AggregateRoot` marshaling methods.
+- Added `NoSnapshotBehavior` embeddable type for aggregates that don't support
+  binary snapshots.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ persistence.
   message delivery, persistence, and telemetry.
 
 - **Type-agnostic** — Dogma lets you represent messages and application state
-  using any Go types that you can marshal to a byte slice, with built-in support
-  for JSON and Protocol Buffers.
+  using any Go types that implement the standard [`BinaryMarshaler`] and
+  [`BinaryUnmarshaler`] interfaces.
 
 - **Flexible persistence** — Dogma supports a range of storage options including
   PostgreSQL and Amazon DynamoDB, enabling use across diverse environments.
@@ -112,3 +112,5 @@ For reference material, please see the [API documentation] and [glossary].
 [testkit]: https://github.com/dogmatiq/testkit
 [veracity]: https://github.com/dogmatiq/veracity
 [verity]: https://github.com/dogmatiq/verity
+[`BinaryMarshaler`]: https://pkg.go.dev/encoding#BinaryMarshaler
+[`BinaryUnmarshaler`]: https://pkg.go.dev/encoding#BinaryUnmarshaler

--- a/aggregate.go
+++ b/aggregate.go
@@ -94,7 +94,7 @@ type AggregateRoot interface {
 	//
 	// Snapshots are an optimization that reduces the number of events applied
 	// when loading an aggregate instance from its event history. Aggregates
-	// that produce few events over their instances lifetime may omit snapshot
+	// that produce few events over their instances' lifetime may omit snapshot
 	// support by embedding [NoSnapshotBehavior] or returning [ErrNotSupported].
 	MarshalBinary() ([]byte, error)
 

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -1,0 +1,31 @@
+package dogma_test
+
+import (
+	"testing"
+
+	. "github.com/dogmatiq/dogma"
+)
+
+func TestNoSnapshotBehavior(t *testing.T) {
+	var v NoSnapshotBehavior
+
+	t.Run("func MarshalBinary()", func(t *testing.T) {
+		t.Run("it returns ErrNotSupported", func(t *testing.T) {
+			if _, err := v.MarshalBinary(); err != ErrNotSupported {
+				t.Fatal(err)
+			}
+		})
+	})
+
+	t.Run("func UnmarshalBinary()", func(t *testing.T) {
+		t.Run("it returns ErrNotSupported", func(t *testing.T) {
+			if err := v.UnmarshalBinary([]byte{1, 2, 3}); err != ErrNotSupported {
+				t.Fatal(err)
+			}
+		})
+	})
+}
+
+func init() {
+	assertIsComparable(NoSnapshotBehavior{})
+}

--- a/docs/adr/0028-binary-marshaling.md
+++ b/docs/adr/0028-binary-marshaling.md
@@ -1,0 +1,54 @@
+# 28. Self-marshaling types
+
+Date: 2025-10-07
+
+## Status
+
+Accepted
+
+- References [27. Message type registry](0027-message-type-registry.md)
+
+## Context
+
+In a production system, all implementations of `AggregateRoot`, `ProcessRoot`
+and `Message` must be serialisable to be useful. Even though aggregate roots can
+be reconstructed from historical events, it's still useful to persist a snapshot
+of the aggregate root as an optimization.
+
+Currently, this serialisation is handled by the `enginekit/marshaler` package.
+It supports multiple "codecs", such as Protocol Buffers, JSON and CBOR, and
+provides a HTTP-like system for falling back based on message media type.
+
+While this system is entirely functional, it means that engine implementations
+(`enginekit`, in practice) must support any possible encoding an application
+may wish to use.
+
+## Decision
+
+We will change the `Message`, `AggregateRoot` and `ProcessRoot` interfaces to
+adhere to Go's standard [`encoding.BinaryMarshaler`] and
+[`encoding.BinaryUnmarshaler`] interfaces.
+
+Engines will use each message type's UUID, introduced in [ADR-27], as a
+persistence-safe identifier for the message type. A new zero-value message type
+can be constructed based on the UUID before calling `UnmarshalBinary()`.
+
+## Consequences
+
+Application developers are now responsible for implementing the
+`MarshalBinary()` and `UnmarshalBinary()` methods on their message types,
+aggregate roots and process roots. This puts control of the encoding format in
+the hands of the application developer, but does introduce some boilerplate. We
+may need to develop code generation utilities to help with this. The
+[`dogmatiq/primo`] module can generate the marshaling methods for Protocol
+Buffers messages.
+
+Engines no longer need to provide a marshaling mechanism. Accordingly,
+`enginekit/marshaler` package is no longer needed and may be removed.
+
+<!-- references -->
+
+[ADR-27]: 0027-message-type-registry.md
+[`encoding.BinaryMarshaler`]: https://pkg.go.dev/encoding#BinaryMarshaler
+[`encoding.BinaryUnmarshaler`]: https://pkg.go.dev/encoding#BinaryUnmarshaler
+[`dogmatiq/primo`]: http://github.com/dogmatiq/primo

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,3 +38,4 @@ the ADR documents.
 * [25. Prevent reverting ended processes](0025-prevent-reverting-ended-processes.md)
 * [26. Event-stream based projection OCC](0026-event-stream-based-projection-occ.md)
 * [27. Message type registry](0027-message-type-registry.md)
+* [28. Self-marshaling types](0028-binary-marshaling.md)

--- a/error.go
+++ b/error.go
@@ -1,0 +1,13 @@
+package dogma
+
+import "errors"
+
+var (
+	// ErrNotSupported is the error returned when a feature is not supported
+	// by a particular implementation.
+	//
+	// It may be returned by:
+	//  - [AggregateRoot].MarshalBinary
+	//  - [AggregateRoot].UnmarshalBinary
+	ErrNotSupported = errors.New("not supported")
+)

--- a/process.go
+++ b/process.go
@@ -140,9 +140,6 @@ type ProcessMessageHandler interface {
 // It encapsulates process logic and provides a way to inspect the current state
 // when making decisions about which commands to execute and which timeouts to
 // schedule.
-//
-// This interface is currently equivalent to [any], but is a distinct type to
-// allow future extensions without breaking compatibility.
 type ProcessRoot interface {
 	// MarshalBinary returns a binary representation of the process instsance's
 	// current state.

--- a/process.go
+++ b/process.go
@@ -2,6 +2,7 @@ package dogma
 
 import (
 	"context"
+	"errors"
 	"time"
 )
 
@@ -142,7 +143,17 @@ type ProcessMessageHandler interface {
 //
 // This interface is currently equivalent to [any], but is a distinct type to
 // allow future extensions without breaking compatibility.
-type ProcessRoot any
+type ProcessRoot interface {
+	// MarshalBinary returns a binary representation of the process instsance's
+	// current state.
+	MarshalBinary() ([]byte, error)
+
+	// UnmarshalBinary populates the process instance's state from its binary
+	// representation.
+	//
+	// The implementation must clone the data if it is used after returning.
+	UnmarshalBinary(data []byte) error
+}
 
 // ProcessConfigurer is the interface that a [ProcessMessageHandler] uses to
 // declare its configuration.
@@ -278,3 +289,14 @@ func (StatelessProcessBehavior) New() ProcessRoot {
 var StatelessProcessRoot ProcessRoot = statelessProcessRoot{}
 
 type statelessProcessRoot struct{}
+
+func (statelessProcessRoot) MarshalBinary() ([]byte, error) {
+	return nil, nil
+}
+
+func (statelessProcessRoot) UnmarshalBinary(data []byte) error {
+	if len(data) != 0 {
+		return errors.New("cannot unmarshal non-empty data into stateless process")
+	}
+	return nil
+}

--- a/process_test.go
+++ b/process_test.go
@@ -7,14 +7,46 @@ import (
 	. "github.com/dogmatiq/dogma"
 )
 
-func TestStatelessProcessBehavior_New_ReturnsStatelessProcessRoot(t *testing.T) {
+func TestStatelessProcess(t *testing.T) {
 	var v StatelessProcessBehavior
 
-	r := v.New()
+	root := v.New()
 
-	if r != StatelessProcessRoot {
+	if root != StatelessProcessRoot {
 		t.Fatal("unexpected value returned")
 	}
+
+	t.Run("func MarshalBinary()", func(t *testing.T) {
+		t.Run("it returns an empty slice", func(t *testing.T) {
+			data, err := root.MarshalBinary()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(data) != 0 {
+				t.Fatal("expected empty slice")
+			}
+		})
+	})
+
+	t.Run("func UnmarshalBinary()", func(t *testing.T) {
+		t.Run("it returns nil if the data is empty", func(t *testing.T) {
+			if err := root.UnmarshalBinary(nil); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := root.UnmarshalBinary([]byte{}); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		t.Run("it returns an error if the data is not empty", func(t *testing.T) {
+			err := root.UnmarshalBinary([]byte{1, 2, 3})
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	})
 }
 
 func TestNoTimeoutMessagesBehavior(t *testing.T) {


### PR DESCRIPTION
This PR adds marshaling related methods to `AggregateRoot` and `ProcessRoot`.

Marshaling of aggregates is used to implement snapshots, and is therefore optional, since it's just an optimisation. I chose to represent lock of support by introducing an `ErrNotSupported` error and sticking to the `MarshalBinary()` / `UnmarshalBinary()` methods described by the `encoding.BinaryMarshaler` and `BinaryUnmarshaler` interfaces so that we can take advantage of the new Primo feature that generates these methods for Protocol Buffers messages, which we often use as the implementation of aggregate/process roots.

Fixes #176
