### PR TITLE
Genericize aggregate and process handlers by root type

### DIFF
--- a/.vale/config/vocabularies/Go/accept.txt
+++ b/.vale/config/vocabularies/Go/accept.txt
@@ -3,3 +3,4 @@ goroutines?
 ok
 exported
 unexported
+untyped

--- a/.vale/config/vocabularies/Technical/accept.txt
+++ b/.vale/config/vocabularies/Technical/accept.txt
@@ -11,6 +11,7 @@
 [Ee]ventually
 [Ee]xactly
 [Ee]xecute
+[Gg]enericize[sd]?
 [Ee]xecuted
 [Ee]xecution
 [Ee]xtensible
@@ -23,6 +24,7 @@
 [Mm]ultiple
 [Oo]nly
 [Oo]verspecified
+[Pp]arameteriz(e[sd]?|ing)
 [Pp]urchase
 [Pp]urchase
 [Ss]harding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,19 @@ for aggregate roots and process roots.
 
 ### Changed
 
-- **[BC]** `AggregateMessageHandler` is now parameterized by its `AggregateRoot` type.
-- **[BC]** `ProcessMessageHandler` is now parameterized by its `ProcessRoot` type.
-- **[BC]** `AggregateCommandScope` is now parameterized by the `AggregateRoot` type.
-- **[BC]** `ProcessScope`, `ProcessEventScope`, and `ProcessTimeoutScope` are now parameterized by the `ProcessRoot` type.
-- **[BC]** `NoTimeoutMessagesBehavior` is now parameterized by the `ProcessRoot` type.
-- **[BC]** `StatelessProcessRoot` is now an exported struct type (was a package-level variable).
-- **[BC]** `ViaAggregate()` and `ViaProcess()` are now generic functions.
+- **[BC]** `StatelessProcessRoot` is now an exported struct type instead of a
+  package-level variable.
+- **[BC]** The following types and functions are now parameterized by their
+  concrete `AggregateRoot` or `ProcessRoot` type:
+  - `AggregateMessageHandler`
+  - `AggregateCommandScope`
+  - `ProcessMessageHandler`
+  - `ProcessScope`
+  - `ProcessEventScope`
+  - `ProcessTimeoutScope`
+  - `NoTimeoutMessagesBehavior`
+  - `ViaAggregate()`
+  - `ViaProcess()`
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ The format is based on [Keep a Changelog], and this project adheres to
 [bc]: https://github.com/dogmatiq/.github/blob/main/VERSIONING.md#changelogs
 [engine bc]: https://github.com/dogmatiq/.github/blob/main/VERSIONING.md#changelogs
 
+## [Unreleased]
+
+This release genericizes `AggregateMessageHandler` and
+`ProcessMessageHandler` by their root type, providing compile-time type safety
+for aggregate roots and process roots.
+
+### Changed
+
+- **[BC]** `AggregateMessageHandler` is now parameterized by its `AggregateRoot` type.
+- **[BC]** `ProcessMessageHandler` is now parameterized by its `ProcessRoot` type.
+- **[BC]** `AggregateCommandScope` is now parameterized by the `AggregateRoot` type.
+- **[BC]** `ProcessScope`, `ProcessEventScope`, and `ProcessTimeoutScope` are now parameterized by the `ProcessRoot` type.
+- **[BC]** `NoTimeoutMessagesBehavior` is now parameterized by the `ProcessRoot` type.
+- **[BC]** `StatelessProcessRoot` is now an exported struct type (was a package-level variable).
+- **[BC]** `ViaAggregate()` and `ViaProcess()` are now generic functions.
+
+### Added
+
+- Added `UntypedAggregateMessageHandler()` and `UntypedProcessMessageHandler()`.
+- Added `UnwrapHandler()` for recursively unwrapping handler adaptors.
+
 ## [0.22.0] - 2026-04-24
 
 ### Changed

--- a/aggregate.go
+++ b/aggregate.go
@@ -188,41 +188,21 @@ func (NoSnapshotBehavior) UnmarshalBinary([]byte) error {
 	return ErrNotSupported
 }
 
-// An UntypedAggregateMessageHandler is a type-erased version of
-// [AggregateMessageHandler] that the engine uses to interact with aggregate
-// message handlers without knowing the concrete [AggregateRoot] type.
-type UntypedAggregateMessageHandler interface {
-	Configure(c AggregateConfigurer)
-	New() AggregateRoot
-	RouteCommandToInstance(c Command) string
-	HandleCommand(AggregateRoot, UntypedAggregateCommandScope, Command)
+// UntypedAggregateMessageHandler returns a type-erased adaptor for h that
+// implements [AggregateMessageHandler] with [AggregateRoot] as the type
+// parameter.
+//
+// Use [UnwrapHandler] to recover the original handler from the returned value.
+func UntypedAggregateMessageHandler[R AggregateRoot](h AggregateMessageHandler[R]) AggregateMessageHandler[AggregateRoot] {
+	if h == nil {
+		panic("handler cannot be nil")
+	}
+	return &untypedAggregateMessageHandler[R]{h}
 }
 
-// UntypedAggregateCommandScope is a type-erased version of
-// [AggregateCommandScope] that the engine uses to provide the scope
-// implementation without knowing the concrete [AggregateRoot] type.
-type UntypedAggregateCommandScope interface {
-	HandlerScope
-
-	// InstanceID returns the ID of the aggregate instance that the [Command]
-	// targets, as returned by [AggregateMessageHandler].RouteCommandToInstance.
-	InstanceID() string
-
-	// RecordEvent records an [Event] that results from handling the [Command].
-	//
-	// It applies the event to the aggregate root by calling
-	// [AggregateRoot].ApplyEvent, making the state changes visible to the
-	// handler immediately.
-	//
-	// The engine persists all events recorded within this scope in a single
-	// atomic operation after the [AggregateMessageHandler] finishes handling
-	// the inbound command.
-	RecordEvent(Event)
-}
-
-// untypedAggregateMessageHandler adapts an [AggregateMessageHandler] to the
-// [UntypedAggregateMessageHandler] interface by performing type assertions on
-// the [AggregateRoot].
+// untypedAggregateMessageHandler adapts an [AggregateMessageHandler] to
+// [AggregateMessageHandler] with [AggregateRoot] as the type parameter by
+// performing type assertions on the [AggregateRoot].
 type untypedAggregateMessageHandler[R AggregateRoot] struct {
 	handler AggregateMessageHandler[R]
 }
@@ -241,7 +221,7 @@ func (a *untypedAggregateMessageHandler[R]) RouteCommandToInstance(c Command) st
 
 func (a *untypedAggregateMessageHandler[R]) HandleCommand(
 	r AggregateRoot,
-	s UntypedAggregateCommandScope,
+	s AggregateCommandScope[AggregateRoot],
 	c Command,
 ) {
 	a.handler.HandleCommand(r.(R), s, c)

--- a/aggregate.go
+++ b/aggregate.go
@@ -21,7 +21,9 @@ package dogma
 //
 // The engine may call the handler's methods from multiple goroutines
 // concurrently.
-type AggregateMessageHandler interface {
+//
+// R is the application-defined [AggregateRoot] type for this handler.
+type AggregateMessageHandler[R AggregateRoot] interface {
 	// Configure declares the handler's configuration by calling methods on c.
 	//
 	// The configuration includes the handler's identity and message routes.
@@ -30,13 +32,13 @@ type AggregateMessageHandler interface {
 	// produce the same configuration each time it's called.
 	Configure(c AggregateConfigurer)
 
-	// New returns a new [AggregateRoot] representing the initial state of an
+	// New returns a new value of R representing the initial state of an
 	// aggregate instance.
 	//
 	// The engine calls this method to get a "blank slate" when handling the
 	// first [Command] for a new instance or when reconstructing an existing
 	// instance from its historical [Event] messages.
-	New() AggregateRoot
+	New() R
 
 	// RouteCommandToInstance returns the ID of the aggregate instance that c
 	// targets.
@@ -72,8 +74,8 @@ type AggregateMessageHandler interface {
 	//
 	// The handler may retain or mutate c and the values within it.
 	HandleCommand(
-		r AggregateRoot,
-		s AggregateCommandScope,
+		r R,
+		s AggregateCommandScope[R],
 		c Command,
 	)
 }
@@ -144,7 +146,9 @@ type AggregateConfigurer interface {
 
 // AggregateCommandScope represents the context within which an
 // [AggregateMessageHandler] handles a [Command] message.
-type AggregateCommandScope interface {
+//
+// R is the application-defined [AggregateRoot] type for this handler.
+type AggregateCommandScope[R AggregateRoot] interface {
 	HandlerScope
 
 	// InstanceID returns the ID of the aggregate instance that the [Command]
@@ -182,4 +186,67 @@ func (NoSnapshotBehavior) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary always returns [ErrNotSupported].
 func (NoSnapshotBehavior) UnmarshalBinary([]byte) error {
 	return ErrNotSupported
+}
+
+// An UntypedAggregateMessageHandler is a type-erased version of
+// [AggregateMessageHandler] that the engine uses to interact with aggregate
+// message handlers without knowing the concrete [AggregateRoot] type.
+type UntypedAggregateMessageHandler interface {
+	Configure(c AggregateConfigurer)
+	New() AggregateRoot
+	RouteCommandToInstance(c Command) string
+	HandleCommand(AggregateRoot, UntypedAggregateCommandScope, Command)
+}
+
+// UntypedAggregateCommandScope is a type-erased version of
+// [AggregateCommandScope] that the engine uses to provide the scope
+// implementation without knowing the concrete [AggregateRoot] type.
+type UntypedAggregateCommandScope interface {
+	HandlerScope
+
+	// InstanceID returns the ID of the aggregate instance that the [Command]
+	// targets, as returned by [AggregateMessageHandler].RouteCommandToInstance.
+	InstanceID() string
+
+	// RecordEvent records an [Event] that results from handling the [Command].
+	//
+	// It applies the event to the aggregate root by calling
+	// [AggregateRoot].ApplyEvent, making the state changes visible to the
+	// handler immediately.
+	//
+	// The engine persists all events recorded within this scope in a single
+	// atomic operation after the [AggregateMessageHandler] finishes handling
+	// the inbound command.
+	RecordEvent(Event)
+}
+
+// untypedAggregateMessageHandler adapts an [AggregateMessageHandler] to the
+// [UntypedAggregateMessageHandler] interface by performing type assertions on
+// the [AggregateRoot].
+type untypedAggregateMessageHandler[R AggregateRoot] struct {
+	handler AggregateMessageHandler[R]
+}
+
+func (a *untypedAggregateMessageHandler[R]) Configure(c AggregateConfigurer) {
+	a.handler.Configure(c)
+}
+
+func (a *untypedAggregateMessageHandler[R]) New() AggregateRoot {
+	return a.handler.New()
+}
+
+func (a *untypedAggregateMessageHandler[R]) RouteCommandToInstance(c Command) string {
+	return a.handler.RouteCommandToInstance(c)
+}
+
+func (a *untypedAggregateMessageHandler[R]) HandleCommand(
+	r AggregateRoot,
+	s UntypedAggregateCommandScope,
+	c Command,
+) {
+	a.handler.HandleCommand(r.(R), s, c)
+}
+
+func (a *untypedAggregateMessageHandler[R]) UnwrapHandler() any {
+	return a.handler
 }

--- a/aggregate.go
+++ b/aggregate.go
@@ -192,11 +192,19 @@ func (NoSnapshotBehavior) UnmarshalBinary([]byte) error {
 // implements [AggregateMessageHandler] with [AggregateRoot] as the type
 // parameter.
 //
+// If h already has [AggregateRoot] as its type parameter, it is
+// returned unchanged.
+//
 // Use [UnwrapHandler] to recover the original handler from the returned value.
 func UntypedAggregateMessageHandler[R AggregateRoot](h AggregateMessageHandler[R]) AggregateMessageHandler[AggregateRoot] {
 	if h == nil {
 		panic("handler cannot be nil")
 	}
+
+	if u, ok := any(h).(AggregateMessageHandler[AggregateRoot]); ok {
+		return u
+	}
+
 	return &untypedAggregateMessageHandler[R]{h}
 }
 

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -26,6 +26,92 @@ func TestNoSnapshotBehavior(t *testing.T) {
 	})
 }
 
+func TestUntypedAggregateMessageHandler(t *testing.T) {
+	inner := &aggregateHandlerStub{
+		routeID: "instance-001",
+	}
+	route := expectType[AggregateHandlerRoute](t, ViaAggregate(inner))
+	adaptor := route.Handler()
+
+	t.Run("func Configure()", func(t *testing.T) {
+		t.Run("it delegates to the wrapped handler", func(t *testing.T) {
+			adaptor.Configure(nil)
+			if !inner.configured {
+				t.Fatal("expected Configure to be called on the wrapped handler")
+			}
+		})
+	})
+
+	t.Run("func New()", func(t *testing.T) {
+		t.Run("it returns the root from the wrapped handler", func(t *testing.T) {
+			got := adaptor.New()
+			expectType[aggregateRootStub](t, got)
+		})
+	})
+
+	t.Run("func RouteCommandToInstance()", func(t *testing.T) {
+		t.Run("it delegates to the wrapped handler", func(t *testing.T) {
+			got := adaptor.RouteCommandToInstance(nil)
+			if got != "instance-001" {
+				t.Fatalf("unexpected instance ID: got %q, want %q", got, "instance-001")
+			}
+		})
+	})
+
+	t.Run("func HandleCommand()", func(t *testing.T) {
+		t.Run("it narrows the root type and delegates to the wrapped handler", func(t *testing.T) {
+			adaptor.HandleCommand(aggregateRootStub{}, nil, nil)
+			if !inner.handleCalled {
+				t.Fatal("expected HandleCommand to be called on the wrapped handler")
+			}
+		})
+
+		t.Run("it panics if the root has an unexpected type", func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("expected a panic")
+				}
+			}()
+			adaptor.HandleCommand(nil, nil, nil)
+		})
+	})
+}
+
+type aggregateRootStub struct {
+	NoSnapshotBehavior
+}
+
+func (aggregateRootStub) AggregateInstanceDescription() string { return "" }
+func (aggregateRootStub) ApplyEvent(Event)                     {}
+
+type aggregateHandlerStub struct {
+	configured   bool
+	routeID      string
+	handleCalled bool
+}
+
+var _ AggregateMessageHandler[aggregateRootStub] = &aggregateHandlerStub{}
+
+func (h *aggregateHandlerStub) Configure(AggregateConfigurer) {
+	h.configured = true
+}
+
+func (h *aggregateHandlerStub) New() aggregateRootStub {
+	return aggregateRootStub{}
+}
+
+func (h *aggregateHandlerStub) RouteCommandToInstance(Command) string {
+	return h.routeID
+}
+
+func (h *aggregateHandlerStub) HandleCommand(
+	_ aggregateRootStub,
+	_ AggregateCommandScope[aggregateRootStub],
+	_ Command,
+) {
+	h.handleCalled = true
+}
+
 func init() {
 	assertIsComparable(NoSnapshotBehavior{})
 }

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -36,6 +36,16 @@ func TestUntypedAggregateMessageHandler(t *testing.T) {
 		}
 	})
 
+	t.Run("it returns the handler unchanged if already untyped", func(t *testing.T) {
+		h := &aggregateHandlerStub{}
+		adaptor := UntypedAggregateMessageHandler(h)
+		again := UntypedAggregateMessageHandler(adaptor)
+
+		if again != adaptor {
+			t.Fatal("expected the same handler to be returned")
+		}
+	})
+
 	t.Run("it panics if the handler is nil", func(t *testing.T) {
 		expectPanic(
 			t,

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -27,6 +27,27 @@ func TestNoSnapshotBehavior(t *testing.T) {
 }
 
 func TestUntypedAggregateMessageHandler(t *testing.T) {
+	t.Run("it returns an adaptor that wraps the handler", func(t *testing.T) {
+		h := &aggregateHandlerStub{}
+		adaptor := UntypedAggregateMessageHandler(h)
+
+		if got := UnwrapHandler(adaptor); got != h {
+			t.Fatal("unexpected handler")
+		}
+	})
+
+	t.Run("it panics if the handler is nil", func(t *testing.T) {
+		expectPanic(
+			t,
+			"handler cannot be nil",
+			func() {
+				UntypedAggregateMessageHandler[AggregateRoot](nil)
+			},
+		)
+	})
+}
+
+func TestAggregateMessageHandlerAdaptor(t *testing.T) {
 	inner := &aggregateHandlerStub{
 		routeID: "instance-001",
 	}

--- a/docs/adr/0006-stateless-aggregates-and-processes.md
+++ b/docs/adr/0006-stateless-aggregates-and-processes.md
@@ -6,6 +6,8 @@ Date: 2018-12-11
 
 Accepted
 
+- Referenced by [33. Generic aggregate and process handlers](0033-generic-aggregate-and-process-handlers.md)
+
 ## Context
 
 We need to decide how to represent aggregates and processes that do not have

--- a/docs/adr/0033-generic-aggregate-and-process-handlers.md
+++ b/docs/adr/0033-generic-aggregate-and-process-handlers.md
@@ -1,0 +1,87 @@
+# 33. Generic aggregate and process handlers
+
+Date: 2026-04-25
+
+## Status
+
+Proposed
+
+- References [6. Stateless aggregates and processes][ADR-6]
+
+> [!NOTE]
+> This decision has not yet been accepted and is subject to change.
+
+## Context
+
+`AggregateMessageHandler` and `ProcessMessageHandler` both operate on
+application-defined root types that implement the `AggregateRoot` and
+`ProcessRoot` interfaces. Today, handler methods accept and return the root as
+the interface type rather than the application's concrete type.
+
+This means every handler implementation must type-assert the root it receives.
+For example, `AggregateMessageHandler.HandleCommand()` receives an
+`AggregateRoot` that the handler must assert to its concrete type before use.
+The compiler cannot verify these assertions — a mismatch between the concrete
+type that `New()` returns and the type that `HandleCommand()` asserts is a
+runtime panic, not a compile-time error.
+
+## Decision
+
+We will add a type parameter `R` to the following interfaces, constrained by
+`AggregateRoot` or `ProcessRoot` as appropriate:
+
+- `AggregateMessageHandler`
+- `AggregateCommandScope`
+- `ProcessMessageHandler`
+- `ProcessScope`
+- `ProcessEventScope`
+- `ProcessTimeoutScope`
+
+Engine implementations are unaware of the application's concrete root types, so
+they need a way to represent handlers without that information. Rather than
+introducing separate "untyped" interfaces, we will use the same generic types
+with the constraint interface as the type parameter. For example, an
+application defines `AggregateMessageHandler[ShoppingCart]`, but the engine
+represents the same handler as `AggregateMessageHandler[AggregateRoot]`.
+
+### Dismissed alternatives
+
+**Separate untyped interfaces.** We considered introducing a parallel set of
+interfaces — `UntypedAggregateMessageHandler`, `UntypedAggregateCommandScope`,
+and their process equivalents — for engines to use instead of the generic
+versions. Separate interfaces would make the untyped nature explicit in type
+names, but this would double the number of interfaces with no practical benefit,
+since the scope interfaces would be identical to their generic counterparts and
+the handler interfaces would still need adaptors.
+
+## Consequences
+
+Each handler's `New` method returns `R`, and its message-handling methods
+receive `R` directly. The compiler enforces that the root type is consistent
+across all of a handler's methods, so type assertions are no longer necessary
+unless the handler deliberately uses the interface type as its type parameter.
+
+This is a breaking change to the handler and scope interfaces. Existing code
+must add type parameters to references to these types. Handlers that do not
+want to adopt a concrete root type can use `AggregateRoot` or `ProcessRoot` as
+the type parameter to preserve their current behavior — the generic interfaces
+work without a concrete root type.
+
+`NoTimeoutMessagesBehavior` becomes parameterized by `R` because its
+`HandleTimeout()` method receives a `ProcessTimeoutScope[R]`.
+
+`StatelessProcessRoot` changes from a package-level variable to an exported
+struct type. The current design — a variable holding an interface value — cannot
+serve as a type parameter. [ADR-6] established the stateless root pattern, and
+the struct form preserves the same semantics while being usable as a type
+argument.
+
+Integration and projection handlers are unaffected by this change. They do not
+have root types and remain non-generic.
+
+No current methods on the scope interfaces use `R`, but parameterizing them
+means methods that use `R` can be added later without a breaking change.
+
+<!-- references -->
+
+[ADR-6]: 0006-stateless-aggregates-and-processes.md

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,3 +43,4 @@ the ADR documents.
 * [30. Observe command outcomes via events](0030-observe-command-outcomes-via-events.md)
 * [31. Require retries for idempotency-keyed commands](0031-require-retries-for-idempotency-keyed-commands.md)
 * [32. Message ownership](0032-message-ownership.md)
+* [33. Generic aggregate and process handlers](0033-generic-aggregate-and-process-handlers.md)

--- a/handler.go
+++ b/handler.go
@@ -89,3 +89,27 @@ type HandlerScope interface {
 	// #49412, it has already shipped”.
 	Log(format string, args ...any)
 }
+
+// UnwrapHandler returns the innermost handler wrapped by h.
+//
+// This follows the same convention as [errors.Unwrap]. A handler adaptor can
+// support unwrapping by providing an UnwrapHandler() method that returns the
+// wrapped handler.
+//
+// If h wraps multiple layers, it recurses until it reaches a handler that
+// doesn't implement UnwrapHandler(). It returns h itself if h doesn't wrap
+// another handler.
+func UnwrapHandler(h any) any {
+	type unwrapper interface {
+		UnwrapHandler() any
+	}
+
+	for {
+		u, ok := h.(unwrapper)
+		if !ok {
+			return h
+		}
+
+		h = u.UnwrapHandler()
+	}
+}

--- a/handlerroute.go
+++ b/handlerroute.go
@@ -5,10 +5,7 @@ package dogma
 //
 // Pass the returned [HandlerRoute] to [ApplicationConfigurer].Routes.
 func ViaAggregate[R AggregateRoot](h AggregateMessageHandler[R], _ ...ViaAggregateOption) HandlerRoute {
-	if h == nil {
-		panic("handler cannot be nil")
-	}
-	return AggregateHandlerRoute{handler: &untypedAggregateMessageHandler[R]{h}}
+	return AggregateHandlerRoute{handler: UntypedAggregateMessageHandler(h)}
 }
 
 // ViaProcess configures the [Application] to route messages to and from a
@@ -16,10 +13,7 @@ func ViaAggregate[R AggregateRoot](h AggregateMessageHandler[R], _ ...ViaAggrega
 //
 // Pass the returned [HandlerRoute] to [ApplicationConfigurer].Routes.
 func ViaProcess[R ProcessRoot](h ProcessMessageHandler[R], _ ...ViaProcessOption) HandlerRoute {
-	if h == nil {
-		panic("handler cannot be nil")
-	}
-	return ProcessHandlerRoute{handler: &untypedProcessMessageHandler[R]{h}}
+	return ProcessHandlerRoute{handler: UntypedProcessMessageHandler(h)}
 }
 
 // ViaIntegration configures the [Application] to route messages to and from an
@@ -60,7 +54,7 @@ type (
 	// Use [ViaAggregate] to construct values of this type.
 	AggregateHandlerRoute struct {
 		nocmp
-		handler UntypedAggregateMessageHandler
+		handler AggregateMessageHandler[AggregateRoot]
 	}
 
 	// ProcessHandlerRoute is a [HandlerRoute] that represents a relationship
@@ -69,7 +63,7 @@ type (
 	// See [ViaProcess] to construct values of this type.
 	ProcessHandlerRoute struct {
 		nocmp
-		handler UntypedProcessMessageHandler
+		handler ProcessMessageHandler[ProcessRoot]
 	}
 
 	// IntegrationHandlerRoute is a [HandlerRoute] that represents a
@@ -126,13 +120,13 @@ type (
 	}
 )
 
-// Handler returns the [UntypedAggregateMessageHandler] for r.
-func (r AggregateHandlerRoute) Handler() UntypedAggregateMessageHandler {
+// Handler returns the [AggregateMessageHandler] for r.
+func (r AggregateHandlerRoute) Handler() AggregateMessageHandler[AggregateRoot] {
 	return r.handler
 }
 
-// Handler returns the [UntypedProcessMessageHandler] for r.
-func (r ProcessHandlerRoute) Handler() UntypedProcessMessageHandler {
+// Handler returns the [ProcessMessageHandler] for r.
+func (r ProcessHandlerRoute) Handler() ProcessMessageHandler[ProcessRoot] {
 	return r.handler
 }
 

--- a/handlerroute.go
+++ b/handlerroute.go
@@ -4,22 +4,22 @@ package dogma
 // [AggregateMessageHandler].
 //
 // Pass the returned [HandlerRoute] to [ApplicationConfigurer].Routes.
-func ViaAggregate(h AggregateMessageHandler, _ ...ViaAggregateOption) HandlerRoute {
+func ViaAggregate[R AggregateRoot](h AggregateMessageHandler[R], _ ...ViaAggregateOption) HandlerRoute {
 	if h == nil {
 		panic("handler cannot be nil")
 	}
-	return AggregateHandlerRoute{handler: h}
+	return AggregateHandlerRoute{handler: &untypedAggregateMessageHandler[R]{h}}
 }
 
 // ViaProcess configures the [Application] to route messages to and from a
 // [ProcessMessageHandler].
 //
 // Pass the returned [HandlerRoute] to [ApplicationConfigurer].Routes.
-func ViaProcess(h ProcessMessageHandler, _ ...ViaProcessOption) HandlerRoute {
+func ViaProcess[R ProcessRoot](h ProcessMessageHandler[R], _ ...ViaProcessOption) HandlerRoute {
 	if h == nil {
 		panic("handler cannot be nil")
 	}
-	return ProcessHandlerRoute{handler: h}
+	return ProcessHandlerRoute{handler: &untypedProcessMessageHandler[R]{h}}
 }
 
 // ViaIntegration configures the [Application] to route messages to and from an
@@ -60,7 +60,7 @@ type (
 	// Use [ViaAggregate] to construct values of this type.
 	AggregateHandlerRoute struct {
 		nocmp
-		handler AggregateMessageHandler
+		handler UntypedAggregateMessageHandler
 	}
 
 	// ProcessHandlerRoute is a [HandlerRoute] that represents a relationship
@@ -69,7 +69,7 @@ type (
 	// See [ViaProcess] to construct values of this type.
 	ProcessHandlerRoute struct {
 		nocmp
-		handler ProcessMessageHandler
+		handler UntypedProcessMessageHandler
 	}
 
 	// IntegrationHandlerRoute is a [HandlerRoute] that represents a
@@ -126,13 +126,13 @@ type (
 	}
 )
 
-// Handler returns the [AggregateMessageHandler] for r.
-func (r AggregateHandlerRoute) Handler() AggregateMessageHandler {
+// Handler returns the [UntypedAggregateMessageHandler] for r.
+func (r AggregateHandlerRoute) Handler() UntypedAggregateMessageHandler {
 	return r.handler
 }
 
-// Handler returns the [ProcessMessageHandler] for r.
-func (r ProcessHandlerRoute) Handler() ProcessMessageHandler {
+// Handler returns the [UntypedProcessMessageHandler] for r.
+func (r ProcessHandlerRoute) Handler() UntypedProcessMessageHandler {
 	return r.handler
 }
 

--- a/handlerroute_test.go
+++ b/handlerroute_test.go
@@ -8,13 +8,16 @@ import (
 
 func TestViaAggregate(t *testing.T) {
 	t.Run("it returns a route with the specified handler", func(t *testing.T) {
-		type aggregate struct{ AggregateMessageHandler }
+		type aggregate struct {
+			AggregateMessageHandler[AggregateRoot]
+		}
 
 		h := &aggregate{}
 		r := ViaAggregate(h)
 		x := expectType[AggregateHandlerRoute](t, r)
+		got := UnwrapHandler(x.Handler())
 
-		if x.Handler() != h {
+		if got != h {
 			t.Fatal("unexpected handler")
 		}
 	})
@@ -24,7 +27,7 @@ func TestViaAggregate(t *testing.T) {
 			t,
 			`handler cannot be nil`,
 			func() {
-				ViaAggregate(nil)
+				ViaAggregate[AggregateRoot](nil)
 			},
 		)
 	})
@@ -32,13 +35,16 @@ func TestViaAggregate(t *testing.T) {
 
 func TestViaProcess(t *testing.T) {
 	t.Run("it returns a route with the specified handler", func(t *testing.T) {
-		type process struct{ ProcessMessageHandler }
+		type process struct {
+			ProcessMessageHandler[ProcessRoot]
+		}
 
 		h := &process{}
 		r := ViaProcess(h)
 		x := expectType[ProcessHandlerRoute](t, r)
+		got := UnwrapHandler(x.Handler())
 
-		if x.Handler() != h {
+		if got != h {
 			t.Fatal("unexpected handler")
 		}
 	})
@@ -48,7 +54,7 @@ func TestViaProcess(t *testing.T) {
 			t,
 			`handler cannot be nil`,
 			func() {
-				ViaProcess(nil)
+				ViaProcess[ProcessRoot](nil)
 			},
 		)
 	})

--- a/process.go
+++ b/process.go
@@ -33,7 +33,9 @@ import (
 //
 // The engine may call the handler's methods from multiple goroutines
 // concurrently.
-type ProcessMessageHandler interface {
+//
+// R is the application-defined [ProcessRoot] type for this handler.
+type ProcessMessageHandler[R ProcessRoot] interface {
 	// Configure declares the handler's configuration by calling methods on c.
 	//
 	// The configuration includes the handler's identity and message routes.
@@ -42,7 +44,7 @@ type ProcessMessageHandler interface {
 	// produce the same configuration each time it's called.
 	Configure(c ProcessConfigurer)
 
-	// New returns a new [ProcessRoot] representing the initial state of a
+	// New returns a new value of R representing the initial state of a
 	// process instance.
 	//
 	// The engine calls this method to get a "blank slate" when handling the
@@ -51,7 +53,7 @@ type ProcessMessageHandler interface {
 	//
 	// Not all processes maintain state. Embed [StatelessProcessBehavior] in the
 	// handler implementation to indicate that the process is stateless.
-	New() ProcessRoot
+	New() R
 
 	// RouteEventToInstance returns the ID of the process instance that e
 	// targets.
@@ -107,8 +109,8 @@ type ProcessMessageHandler interface {
 	// The handler may retain or mutate e and the values within it.
 	HandleEvent(
 		ctx context.Context,
-		r ProcessRoot,
-		s ProcessEventScope,
+		r R,
+		s ProcessEventScope[R],
 		e Event,
 	) error
 
@@ -141,8 +143,8 @@ type ProcessMessageHandler interface {
 	// The handler may retain or mutate t and the values within it.
 	HandleTimeout(
 		ctx context.Context,
-		r ProcessRoot,
-		s ProcessTimeoutScope,
+		r R,
+		s ProcessTimeoutScope[R],
 		t Timeout,
 	) error
 }
@@ -208,7 +210,9 @@ type ProcessConfigurer interface {
 //
 //   - [ProcessEventScope]
 //   - [ProcessTimeoutScope]
-type ProcessScope interface {
+//
+// R is the application-defined [ProcessRoot] type for this handler.
+type ProcessScope[R ProcessRoot] interface {
 	HandlerScope
 
 	// InstanceID returns the ID of the process instance that the message
@@ -251,8 +255,10 @@ type ProcessScope interface {
 
 // ProcessEventScope represents the context within which a
 // [ProcessMessageHandler] handles an [Event] message.
-type ProcessEventScope interface {
-	ProcessScope
+//
+// R is the application-defined [ProcessRoot] type for this handler.
+type ProcessEventScope[R ProcessRoot] interface {
+	ProcessScope[R]
 
 	// RecordedAt returns the time at which the inbound [Event] occurred.
 	RecordedAt() time.Time
@@ -260,8 +266,10 @@ type ProcessEventScope interface {
 
 // ProcessTimeoutScope represents the context within which a
 // [ProcessMessageHandler] handles a [Timeout] message.
-type ProcessTimeoutScope interface {
-	ProcessScope
+//
+// R is the application-defined [ProcessRoot] type for this handler.
+type ProcessTimeoutScope[R ProcessRoot] interface {
+	ProcessScope[R]
 
 	// ScheduledFor returns the time at which the timeout occurred.
 	//
@@ -284,13 +292,15 @@ type ProcessRoute interface {
 // Embed this type in a [ProcessMessageHandler] to signal that the handler
 // doesn't schedule timeouts and to avoid boilerplate code that's never
 // used.
-type NoTimeoutMessagesBehavior struct{}
+//
+// R is the application-defined [ProcessRoot] type for this handler.
+type NoTimeoutMessagesBehavior[R ProcessRoot] struct{}
 
 // HandleTimeout panics with the [UnexpectedMessage] value.
-func (NoTimeoutMessagesBehavior) HandleTimeout(
+func (NoTimeoutMessagesBehavior[R]) HandleTimeout(
 	context.Context,
-	ProcessRoot,
-	ProcessTimeoutScope,
+	R,
+	ProcessTimeoutScope[R],
 	Timeout,
 ) error {
 	panic(UnexpectedMessage)
@@ -303,9 +313,9 @@ func (NoTimeoutMessagesBehavior) HandleTimeout(
 // stateless and to avoid boilerplate code that's never used.
 type StatelessProcessBehavior struct{}
 
-// New returns [StatelessProcessRoot].
-func (StatelessProcessBehavior) New() ProcessRoot {
-	return StatelessProcessRoot
+// New returns a zero-value [StatelessProcessRoot].
+func (StatelessProcessBehavior) New() StatelessProcessRoot {
+	return StatelessProcessRoot{}
 }
 
 // StatelessProcessRoot is an empty [ProcessRoot] for processes that don't
@@ -316,21 +326,142 @@ func (StatelessProcessBehavior) New() ProcessRoot {
 //
 // The engine may provide optimized persistence for stateless processes that use
 // this type.
-var StatelessProcessRoot ProcessRoot = statelessProcessRoot{}
+type StatelessProcessRoot struct{}
 
-type statelessProcessRoot struct{}
-
-func (statelessProcessRoot) ProcessInstanceDescription(bool) string {
+func (StatelessProcessRoot) ProcessInstanceDescription(bool) string {
 	return ""
 }
 
-func (statelessProcessRoot) MarshalBinary() ([]byte, error) {
+func (StatelessProcessRoot) MarshalBinary() ([]byte, error) {
 	return nil, nil
 }
 
-func (statelessProcessRoot) UnmarshalBinary(data []byte) error {
+func (StatelessProcessRoot) UnmarshalBinary(data []byte) error {
 	if len(data) != 0 {
 		return errors.New("cannot unmarshal non-empty data into stateless process")
 	}
 	return nil
+}
+
+// An UntypedProcessMessageHandler is a type-erased version of
+// [ProcessMessageHandler] that the engine uses to interact with process message
+// handlers without knowing the concrete [ProcessRoot] type.
+type UntypedProcessMessageHandler interface {
+	Configure(c ProcessConfigurer)
+	New() ProcessRoot
+	RouteEventToInstance(ctx context.Context, e Event) (string, bool, error)
+	HandleEvent(context.Context, ProcessRoot, UntypedProcessEventScope, Event) error
+	HandleTimeout(context.Context, ProcessRoot, UntypedProcessTimeoutScope, Timeout) error
+}
+
+// UntypedProcessScope is a type-erased version of [ProcessScope] that the
+// engine uses to provide the scope implementation without knowing the concrete
+// [ProcessRoot] type.
+type UntypedProcessScope interface {
+	HandlerScope
+
+	// InstanceID returns the ID of the process instance that the message
+	// targets.
+	//
+	// When handling an [Event] message, it returns the ID produced by
+	// [ProcessMessageHandler].RouteEventToInstance during routing.
+	//
+	// When handling a [Timeout] message, it returns the ID of the instance that
+	// scheduled the timeout.
+	InstanceID() string
+
+	// End signals the end of a process.
+	//
+	// The engine discards the instance's state, cancels any pending [Timeout]
+	// messages. It ignores any future messages that target the ended instance.
+	End()
+
+	// ExecuteCommand submits a [Command] for execution.
+	//
+	// The engine persists all commands and timeouts produced within this scope
+	// in a single atomic operation after the [ProcessMessageHandler] finishes
+	// handling the inbound message. If the handler returns a non-nil error, the
+	// engine discards the messages.
+	//
+	// This method panics if the process instance has ended.
+	ExecuteCommand(Command)
+
+	// ScheduleTimeout schedules a [Timeout] message to occur at the specified
+	// time.
+	//
+	// The engine persists all commands and timeouts produced within this scope
+	// in a single atomic operation after the [ProcessMessageHandler] finishes
+	// handling the inbound message. If the handler returns a non-nil error, the
+	// engine discards the messages.
+	//
+	// This method panics if the process instance has ended.
+	ScheduleTimeout(Timeout, time.Time)
+}
+
+// UntypedProcessEventScope is a type-erased version of [ProcessEventScope]
+// that the engine uses to provide the scope implementation without knowing the
+// concrete [ProcessRoot] type.
+type UntypedProcessEventScope interface {
+	UntypedProcessScope
+
+	// RecordedAt returns the time at which the inbound [Event] occurred.
+	RecordedAt() time.Time
+}
+
+// UntypedProcessTimeoutScope is a type-erased version of
+// [ProcessTimeoutScope] that the engine uses to provide the scope
+// implementation without knowing the concrete [ProcessRoot] type.
+type UntypedProcessTimeoutScope interface {
+	UntypedProcessScope
+
+	// ScheduledFor returns the time at which the timeout occurred.
+	//
+	// Even though the engine attempts to deliver timeouts at their scheduled
+	// time, it may deliver them later when recovering from downtime or retrying
+	// after a failure.
+	ScheduledFor() time.Time
+}
+
+// untypedProcessMessageHandler adapts a [ProcessMessageHandler] to the
+// [UntypedProcessMessageHandler] interface by performing type assertions on
+// the [ProcessRoot].
+type untypedProcessMessageHandler[R ProcessRoot] struct {
+	handler ProcessMessageHandler[R]
+}
+
+func (a *untypedProcessMessageHandler[R]) Configure(c ProcessConfigurer) {
+	a.handler.Configure(c)
+}
+
+func (a *untypedProcessMessageHandler[R]) New() ProcessRoot {
+	return a.handler.New()
+}
+
+func (a *untypedProcessMessageHandler[R]) RouteEventToInstance(
+	ctx context.Context,
+	e Event,
+) (string, bool, error) {
+	return a.handler.RouteEventToInstance(ctx, e)
+}
+
+func (a *untypedProcessMessageHandler[R]) HandleEvent(
+	ctx context.Context,
+	r ProcessRoot,
+	s UntypedProcessEventScope,
+	e Event,
+) error {
+	return a.handler.HandleEvent(ctx, r.(R), s, e)
+}
+
+func (a *untypedProcessMessageHandler[R]) HandleTimeout(
+	ctx context.Context,
+	r ProcessRoot,
+	s UntypedProcessTimeoutScope,
+	t Timeout,
+) error {
+	return a.handler.HandleTimeout(ctx, r.(R), s, t)
+}
+
+func (a *untypedProcessMessageHandler[R]) UnwrapHandler() any {
+	return a.handler
 }

--- a/process.go
+++ b/process.go
@@ -328,14 +328,19 @@ func (StatelessProcessBehavior) New() StatelessProcessRoot {
 // this type.
 type StatelessProcessRoot struct{}
 
+// ProcessInstanceDescription returns an empty string, as stateless processes
+// have no meaningful state to describe.
 func (StatelessProcessRoot) ProcessInstanceDescription(bool) string {
 	return ""
 }
 
+// MarshalBinary returns nil, as stateless processes have no state to persist.
 func (StatelessProcessRoot) MarshalBinary() ([]byte, error) {
 	return nil, nil
 }
 
+// UnmarshalBinary returns an error if data is non-empty, as stateless
+// processes have no state to restore.
 func (StatelessProcessRoot) UnmarshalBinary(data []byte) error {
 	if len(data) != 0 {
 		return errors.New("cannot unmarshal non-empty data into stateless process")
@@ -346,11 +351,19 @@ func (StatelessProcessRoot) UnmarshalBinary(data []byte) error {
 // UntypedProcessMessageHandler returns a type-erased adaptor for h that
 // implements [ProcessMessageHandler] with [ProcessRoot] as the type parameter.
 //
+// If h already has [ProcessRoot] as its type parameter, it is returned
+// unchanged.
+//
 // Use [UnwrapHandler] to recover the original handler from the returned value.
 func UntypedProcessMessageHandler[R ProcessRoot](h ProcessMessageHandler[R]) ProcessMessageHandler[ProcessRoot] {
 	if h == nil {
 		panic("handler cannot be nil")
 	}
+
+	if u, ok := any(h).(ProcessMessageHandler[ProcessRoot]); ok {
+		return u
+	}
+
 	return &untypedProcessMessageHandler[R]{h}
 }
 

--- a/process.go
+++ b/process.go
@@ -343,88 +343,20 @@ func (StatelessProcessRoot) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
-// An UntypedProcessMessageHandler is a type-erased version of
-// [ProcessMessageHandler] that the engine uses to interact with process message
-// handlers without knowing the concrete [ProcessRoot] type.
-type UntypedProcessMessageHandler interface {
-	Configure(c ProcessConfigurer)
-	New() ProcessRoot
-	RouteEventToInstance(ctx context.Context, e Event) (string, bool, error)
-	HandleEvent(context.Context, ProcessRoot, UntypedProcessEventScope, Event) error
-	HandleTimeout(context.Context, ProcessRoot, UntypedProcessTimeoutScope, Timeout) error
+// UntypedProcessMessageHandler returns a type-erased adaptor for h that
+// implements [ProcessMessageHandler] with [ProcessRoot] as the type parameter.
+//
+// Use [UnwrapHandler] to recover the original handler from the returned value.
+func UntypedProcessMessageHandler[R ProcessRoot](h ProcessMessageHandler[R]) ProcessMessageHandler[ProcessRoot] {
+	if h == nil {
+		panic("handler cannot be nil")
+	}
+	return &untypedProcessMessageHandler[R]{h}
 }
 
-// UntypedProcessScope is a type-erased version of [ProcessScope] that the
-// engine uses to provide the scope implementation without knowing the concrete
-// [ProcessRoot] type.
-type UntypedProcessScope interface {
-	HandlerScope
-
-	// InstanceID returns the ID of the process instance that the message
-	// targets.
-	//
-	// When handling an [Event] message, it returns the ID produced by
-	// [ProcessMessageHandler].RouteEventToInstance during routing.
-	//
-	// When handling a [Timeout] message, it returns the ID of the instance that
-	// scheduled the timeout.
-	InstanceID() string
-
-	// End signals the end of a process.
-	//
-	// The engine discards the instance's state, cancels any pending [Timeout]
-	// messages. It ignores any future messages that target the ended instance.
-	End()
-
-	// ExecuteCommand submits a [Command] for execution.
-	//
-	// The engine persists all commands and timeouts produced within this scope
-	// in a single atomic operation after the [ProcessMessageHandler] finishes
-	// handling the inbound message. If the handler returns a non-nil error, the
-	// engine discards the messages.
-	//
-	// This method panics if the process instance has ended.
-	ExecuteCommand(Command)
-
-	// ScheduleTimeout schedules a [Timeout] message to occur at the specified
-	// time.
-	//
-	// The engine persists all commands and timeouts produced within this scope
-	// in a single atomic operation after the [ProcessMessageHandler] finishes
-	// handling the inbound message. If the handler returns a non-nil error, the
-	// engine discards the messages.
-	//
-	// This method panics if the process instance has ended.
-	ScheduleTimeout(Timeout, time.Time)
-}
-
-// UntypedProcessEventScope is a type-erased version of [ProcessEventScope]
-// that the engine uses to provide the scope implementation without knowing the
-// concrete [ProcessRoot] type.
-type UntypedProcessEventScope interface {
-	UntypedProcessScope
-
-	// RecordedAt returns the time at which the inbound [Event] occurred.
-	RecordedAt() time.Time
-}
-
-// UntypedProcessTimeoutScope is a type-erased version of
-// [ProcessTimeoutScope] that the engine uses to provide the scope
-// implementation without knowing the concrete [ProcessRoot] type.
-type UntypedProcessTimeoutScope interface {
-	UntypedProcessScope
-
-	// ScheduledFor returns the time at which the timeout occurred.
-	//
-	// Even though the engine attempts to deliver timeouts at their scheduled
-	// time, it may deliver them later when recovering from downtime or retrying
-	// after a failure.
-	ScheduledFor() time.Time
-}
-
-// untypedProcessMessageHandler adapts a [ProcessMessageHandler] to the
-// [UntypedProcessMessageHandler] interface by performing type assertions on
-// the [ProcessRoot].
+// untypedProcessMessageHandler adapts a [ProcessMessageHandler] to
+// [ProcessMessageHandler] with [ProcessRoot] as the type parameter by
+// performing type assertions on the [ProcessRoot].
 type untypedProcessMessageHandler[R ProcessRoot] struct {
 	handler ProcessMessageHandler[R]
 }
@@ -447,7 +379,7 @@ func (a *untypedProcessMessageHandler[R]) RouteEventToInstance(
 func (a *untypedProcessMessageHandler[R]) HandleEvent(
 	ctx context.Context,
 	r ProcessRoot,
-	s UntypedProcessEventScope,
+	s ProcessEventScope[ProcessRoot],
 	e Event,
 ) error {
 	return a.handler.HandleEvent(ctx, r.(R), s, e)
@@ -456,7 +388,7 @@ func (a *untypedProcessMessageHandler[R]) HandleEvent(
 func (a *untypedProcessMessageHandler[R]) HandleTimeout(
 	ctx context.Context,
 	r ProcessRoot,
-	s UntypedProcessTimeoutScope,
+	s ProcessTimeoutScope[ProcessRoot],
 	t Timeout,
 ) error {
 	return a.handler.HandleTimeout(ctx, r.(R), s, t)

--- a/process_test.go
+++ b/process_test.go
@@ -76,6 +76,27 @@ func TestNoTimeoutMessagesBehavior(t *testing.T) {
 }
 
 func TestUntypedProcessMessageHandler(t *testing.T) {
+	t.Run("it returns an adaptor that wraps the handler", func(t *testing.T) {
+		h := &processHandlerStub{}
+		adaptor := UntypedProcessMessageHandler(h)
+
+		if got := UnwrapHandler(adaptor); got != h {
+			t.Fatal("unexpected handler")
+		}
+	})
+
+	t.Run("it panics if the handler is nil", func(t *testing.T) {
+		expectPanic(
+			t,
+			"handler cannot be nil",
+			func() {
+				UntypedProcessMessageHandler[ProcessRoot](nil)
+			},
+		)
+	})
+}
+
+func TestProcessMessageHandlerAdaptor(t *testing.T) {
 	inner := &processHandlerStub{
 		routeID: "instance-001",
 		routeOK: true,

--- a/process_test.go
+++ b/process_test.go
@@ -1,6 +1,7 @@
 package dogma_test
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/dogmatiq/dogma"
@@ -72,6 +73,139 @@ func TestNoTimeoutMessagesBehavior(t *testing.T) {
 			v.HandleTimeout(t.Context(), nil, nil, nil)
 		},
 	)
+}
+
+func TestUntypedProcessMessageHandler(t *testing.T) {
+	inner := &processHandlerStub{
+		routeID: "instance-001",
+		routeOK: true,
+	}
+	route := expectType[ProcessHandlerRoute](t, ViaProcess(inner))
+	adaptor := route.Handler()
+
+	t.Run("func Configure()", func(t *testing.T) {
+		t.Run("it delegates to the wrapped handler", func(t *testing.T) {
+			adaptor.Configure(nil)
+			if !inner.configured {
+				t.Fatal("expected Configure to be called on the wrapped handler")
+			}
+		})
+	})
+
+	t.Run("func New()", func(t *testing.T) {
+		t.Run("it returns the root from the wrapped handler", func(t *testing.T) {
+			got := adaptor.New()
+			expectType[processRootStub](t, got)
+		})
+	})
+
+	t.Run("func RouteEventToInstance()", func(t *testing.T) {
+		t.Run("it delegates to the wrapped handler", func(t *testing.T) {
+			id, ok, err := adaptor.RouteEventToInstance(t.Context(), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
+				t.Fatal("expected ok to be true")
+			}
+			if id != "instance-001" {
+				t.Fatalf("unexpected instance ID: got %q, want %q", id, "instance-001")
+			}
+		})
+	})
+
+	t.Run("func HandleEvent()", func(t *testing.T) {
+		t.Run("it narrows the root type and delegates to the wrapped handler", func(t *testing.T) {
+			err := adaptor.HandleEvent(t.Context(), processRootStub{}, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !inner.handleEventCalled {
+				t.Fatal("expected HandleEvent to be called on the wrapped handler")
+			}
+		})
+
+		t.Run("it panics if the root has an unexpected type", func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("expected a panic")
+				}
+			}()
+			adaptor.HandleEvent(t.Context(), nil, nil, nil)
+		})
+	})
+
+	t.Run("func HandleTimeout()", func(t *testing.T) {
+		t.Run("it narrows the root type and delegates to the wrapped handler", func(t *testing.T) {
+			err := adaptor.HandleTimeout(t.Context(), processRootStub{}, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !inner.handleTimeoutCalled {
+				t.Fatal("expected HandleTimeout to be called on the wrapped handler")
+			}
+		})
+
+		t.Run("it panics if the root has an unexpected type", func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("expected a panic")
+				}
+			}()
+			adaptor.HandleTimeout(t.Context(), nil, nil, nil)
+		})
+	})
+}
+
+type processRootStub struct{}
+
+func (processRootStub) ProcessInstanceDescription(bool) string { return "" }
+func (processRootStub) MarshalBinary() ([]byte, error)         { return nil, nil }
+func (processRootStub) UnmarshalBinary([]byte) error           { return nil }
+
+type processHandlerStub struct {
+	configured          bool
+	routeID             string
+	routeOK             bool
+	handleEventCalled   bool
+	handleTimeoutCalled bool
+}
+
+var _ ProcessMessageHandler[processRootStub] = &processHandlerStub{}
+
+func (h *processHandlerStub) Configure(ProcessConfigurer) {
+	h.configured = true
+}
+
+func (h *processHandlerStub) New() processRootStub {
+	return processRootStub{}
+}
+
+func (h *processHandlerStub) RouteEventToInstance(
+	_ context.Context,
+	_ Event,
+) (string, bool, error) {
+	return h.routeID, h.routeOK, nil
+}
+
+func (h *processHandlerStub) HandleEvent(
+	_ context.Context,
+	_ processRootStub,
+	_ ProcessEventScope[processRootStub],
+	_ Event,
+) error {
+	h.handleEventCalled = true
+	return nil
+}
+
+func (h *processHandlerStub) HandleTimeout(
+	_ context.Context,
+	_ processRootStub,
+	_ ProcessTimeoutScope[processRootStub],
+	_ Timeout,
+) error {
+	h.handleTimeoutCalled = true
+	return nil
 }
 
 func init() {

--- a/process_test.go
+++ b/process_test.go
@@ -85,6 +85,16 @@ func TestUntypedProcessMessageHandler(t *testing.T) {
 		}
 	})
 
+	t.Run("it returns the handler unchanged if already untyped", func(t *testing.T) {
+		h := &processHandlerStub{}
+		adaptor := UntypedProcessMessageHandler(h)
+		again := UntypedProcessMessageHandler(adaptor)
+
+		if again != adaptor {
+			t.Fatal("expected the same handler to be returned")
+		}
+	})
+
 	t.Run("it panics if the handler is nil", func(t *testing.T) {
 		expectPanic(
 			t,

--- a/process_test.go
+++ b/process_test.go
@@ -11,7 +11,7 @@ func TestStatelessProcess(t *testing.T) {
 
 	root := v.New()
 
-	if root != StatelessProcessRoot {
+	if root != (StatelessProcessRoot{}) {
 		t.Fatal("unexpected value returned")
 	}
 
@@ -63,7 +63,7 @@ func TestStatelessProcess(t *testing.T) {
 }
 
 func TestNoTimeoutMessagesBehavior(t *testing.T) {
-	var v NoTimeoutMessagesBehavior
+	var v NoTimeoutMessagesBehavior[ProcessRoot]
 
 	expectPanic(
 		t,
@@ -76,5 +76,6 @@ func TestNoTimeoutMessagesBehavior(t *testing.T) {
 
 func init() {
 	assertIsComparable(StatelessProcessBehavior{})
-	assertIsComparable(NoTimeoutMessagesBehavior{})
+	assertIsComparable(NoTimeoutMessagesBehavior[ProcessRoot]{})
+	assertIsComparable(StatelessProcessRoot{})
 }

--- a/projection.go
+++ b/projection.go
@@ -23,7 +23,7 @@ import (
 // To ensure exactly-once event processing, the handler must implement
 // optimistic concurrency control (OCC) based on each event's position within an
 // event stream. The [github.com/dogmatiq/projectionkit] module provides
-// adapters for popular databases, like PostgreSQL and DynamoDB, that handle the
+// adaptors for popular databases, like PostgreSQL and DynamoDB, that handle the
 // OCC details.
 //
 // When a new event route is added to an existing projection, the engine does


### PR DESCRIPTION
Prototype for genericizing aggregate and process handlers by their root type, as discussed in #125.

## Changes

- **Generic handler interfaces**: `AggregateMessageHandler[R AggregateRoot]` and `ProcessMessageHandler[R ProcessRoot]` — developer-facing, with compile-time root type safety.
- **Generic scopes**: `AggregateCommandScope[R]`, `ProcessScope[R]`, `ProcessEventScope[R]`, `ProcessTimeoutScope[R]`.
- **Engine-facing representation**: Engines use the same generic types with the constraint interface as the type parameter (e.g., `AggregateMessageHandler[AggregateRoot]`) — no separate untyped interfaces.
- **Untyped adaptor functions**: `UntypedAggregateMessageHandler()` and `UntypedProcessMessageHandler()` wrap a typed handler into one parameterized by the constraint interface. If the handler already uses the constraint interface, it is returned unchanged.
- **Generic `ViaAggregate`/`ViaProcess`**: Infer `R` from the handler and construct the adaptor internally.
- **`UnwrapHandler(h any) any`**: Recursive unwrapping function following the `errors.Unwrap` convention, addressing configkit#18.
- **`NoTimeoutMessagesBehavior[R ProcessRoot]`**: Now generic.
- **`StatelessProcessRoot`**: Exported concrete type (was unexported struct behind a var).

## Design decisions

- No separate untyped interfaces — the constraint interface as the type parameter serves the same purpose with half the API surface.
- Generic scopes duplicate methods rather than embedding untyped scopes — avoids a semantically backwards "is-a" relationship.
- `R` (not `T`) as the type parameter name — conveys "root".
- No pointer constraint on `R` — the framework never constructs `R`, so it's correct.
- Integration and projection handlers are unchanged (no root type).
- Routes remain non-generic; `Handler()` returns the constraint-parameterized type.
- "Adaptor" spelling matches dogmatiq org convention.

Refs #125