### PR TITLE
Add ADR 0032 and document message ownership in API

### DIFF
--- a/aggregate.go
+++ b/aggregate.go
@@ -69,6 +69,8 @@ type AggregateMessageHandler interface {
 	// guarantee the order, number, or concurrency of those attempts. The
 	// implementation doesn't need to perform any synchronization or idempotency
 	// checks.
+	//
+	// The handler may retain or mutate c and the values within it.
 	HandleCommand(
 		r AggregateRoot,
 		s AggregateCommandScope,
@@ -106,7 +108,9 @@ type AggregateRoot interface {
 	// The engine calls this method when loading the instance from historical
 	// events or recording a new event. It must handle all historical event
 	// types, including those no longer routed to this aggregate.
-	ApplyEvent(Event)
+	//
+	// The root may retain or mutate e and the values within it.
+	ApplyEvent(e Event)
 
 	// MarshalBinary returns a binary representation of the aggregate instance's
 	// current state suitable for use as a snapshot.
@@ -156,7 +160,7 @@ type AggregateCommandScope interface {
 	// The engine persists all events recorded within this scope in a single
 	// atomic operation after the [AggregateMessageHandler] finishes handling
 	// the inbound command.
-	RecordEvent(Event)
+	RecordEvent(e Event)
 }
 
 // AggregateRoute describes a message type that's routed to or from a

--- a/docs/adr/0032-message-ownership.md
+++ b/docs/adr/0032-message-ownership.md
@@ -1,0 +1,77 @@
+# 32. Message ownership
+
+Date: 2026-04-25
+
+## Status
+
+Proposed
+
+> [!NOTE]
+> This decision has not yet been accepted and is subject to change.
+
+## Context
+
+Dogma messages are Go interface values backed by pointer-to-struct types.
+These structs often contain slices, maps, and other reference types that share
+underlying memory when copied by value.
+
+When the engine passes a message to a handler — or when a handler passes a
+message to a scope method — the two sides hold references to the same object
+graph. If either side mutates the message or any value reachable from it, the
+other side observes the change. This creates a class of subtle, hard-to-diagnose
+bugs.
+
+The problem is most pronounced in `AggregateRoot.ApplyEvent`. During replay the
+engine decodes each historical event from storage, producing an independent
+value. During live handling, however, the engine calls `ApplyEvent` with the
+same in-memory value the handler passed to `RecordEvent`. Code that assigns a
+field from the event into the root's state works correctly during replay — the
+decoded event shares no memory with anything else — but silently aliases memory
+during live handling. The root and the engine's copy of the event end up
+pointing at the same slice or map, and a later mutation to one corrupts the
+other.
+
+## Decision
+
+We will establish a message ownership rule: whenever a message value crosses the
+boundary between the engine and the application, the application owns the
+message. Ownership covers the entire object graph reachable from the message,
+not just the top-level value.
+
+The engine is responsible for ensuring that every message value it passes to
+application code is independent of any value the engine retains, and that every
+message value it receives from application code is not affected by subsequent
+use of that value by the application. The application never needs to clone or
+otherwise protect a message value — it can freely read, mutate, or retain any
+message it holds.
+
+This applies at every boundary where messages cross between the engine and the
+application:
+
+- Any handler method that receives a message from the engine, including
+  `AggregateRoot.ApplyEvent()` — even during live handling, where the event must
+  be independent of the value the handler passed to `RecordEvent()`.
+- Any scope method that accepts a message from the handler.
+- `CommandExecutor.ExecuteCommand()`, where external application code dispatches
+  a command into the engine.
+- Event observer callbacks registered via `WithEventObserver()`.
+
+This ADR does not prescribe how the engine achieves independence. An engine
+might marshal the message and decode it later, perform a deep copy, or use any
+other mechanism — including doing nothing at all if it can prove the message is
+not shared. The contract is defined in terms of the observable guarantee, not
+the implementation.
+
+## Consequences
+
+Application developers can write handler and root logic without considering
+whether a message value is shared with the engine. In particular, `ApplyEvent`
+implementations can assign fields from the event directly into root state
+regardless of whether the call occurs during replay or live handling.
+
+The engine bears the full cost of ensuring independence. In practice, engines
+are likely to achieve this by marshaling each message to its binary
+representation immediately and releasing the in-memory value — but this is an
+implementation choice, not a requirement.
+
+<!-- references -->

--- a/docs/adr/0032-message-ownership.md
+++ b/docs/adr/0032-message-ownership.md
@@ -4,10 +4,7 @@ Date: 2026-04-25
 
 ## Status
 
-Proposed
-
-> [!NOTE]
-> This decision has not yet been accepted and is subject to change.
+Accepted
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,3 +42,4 @@ the ADR documents.
 * [29. Retain command idempotency keys](0029-retain-command-idempotency-keys.md)
 * [30. Observe command outcomes via events](0030-observe-command-outcomes-via-events.md)
 * [31. Require retries for idempotency-keyed commands](0031-require-retries-for-idempotency-keyed-commands.md)
+* [32. Message ownership](0032-message-ownership.md)

--- a/executor.go
+++ b/executor.go
@@ -78,8 +78,10 @@ func (o IdempotencyKeyOption) Key() string {
 // recorded as a result of executing a command with
 // [CommandExecutor].ExecuteCommand.
 //
+// The observer may retain or mutate e and the values within it.
+//
 // See [WithEventObserver].
-type EventObserver[T Event] func(ctx context.Context, event T) (satisfied bool, err error)
+type EventObserver[T Event] func(ctx context.Context, e T) (satisfied bool, err error)
 
 // WithEventObserver returns an [ExecuteCommandOption] that observes events of
 // type T recorded while executing a command.

--- a/integration.go
+++ b/integration.go
@@ -39,6 +39,8 @@ type IntegrationMessageHandler interface {
 	// guarantee the order, number, or concurrency of those attempts. The
 	// implementation must ensure that the command's external side-effects are
 	// idempotent and safe for concurrent execution.
+	//
+	// The handler may retain or mutate c and the values within it.
 	HandleCommand(
 		ctx context.Context,
 		s IntegrationCommandScope,

--- a/process.go
+++ b/process.go
@@ -25,6 +25,12 @@ import (
 // customer's purchase, but shouldn't calculate the refund amount or interact
 // directly with the payment processor.
 //
+// When a new event route is added to an existing process, the engine does not
+// guarantee delivery of historical events of the new type. Some, all, or none
+// of the historical events may be delivered, depending on the engine's
+// consumption tracking. To ensure a process sees the complete event history for
+// all of its routes, deploy it as a new handler with a new identity.
+//
 // The engine may call the handler's methods from multiple goroutines
 // concurrently.
 type ProcessMessageHandler interface {
@@ -97,6 +103,8 @@ type ProcessMessageHandler interface {
 	// single aggregate instance, even across scopes. It doesn't guarantee the
 	// relative delivery order of events from different handlers or aggregate
 	// instances.
+	//
+	// The handler may retain or mutate e and the values within it.
 	HandleEvent(
 		ctx context.Context,
 		r ProcessRoot,
@@ -129,6 +137,8 @@ type ProcessMessageHandler interface {
 	//
 	// Not all processes use timeouts. Embed [NoTimeoutMessagesBehavior] in the
 	// handler implementation to indicate that timeout messages aren't used.
+	//
+	// The handler may retain or mutate t and the values within it.
 	HandleTimeout(
 		ctx context.Context,
 		r ProcessRoot,

--- a/projection.go
+++ b/projection.go
@@ -26,6 +26,12 @@ import (
 // adapters for popular databases, like PostgreSQL and DynamoDB, that handle the
 // OCC details.
 //
+// When a new event route is added to an existing projection, the engine does
+// not guarantee delivery of historical events of the new type. Some, all, or
+// none of the historical events may be delivered, depending on the engine's
+// consumption tracking. Call [ProjectionMessageHandler].Reset to clear all
+// checkpoint offsets and rebuild the projection from a complete event history.
+//
 // The engine may call the handler's methods from multiple goroutines
 // concurrently.
 type ProjectionMessageHandler interface {
@@ -64,6 +70,8 @@ type ProjectionMessageHandler interface {
 	// order of events from a single aggregate instance, even across scopes. It
 	// doesn't guarantee the relative delivery order of events from different
 	// handlers or aggregate instances.
+	//
+	// The handler may retain or mutate e and the values within it.
 	//
 	// See:
 	//  - [ProjectionEventScope].StreamID


### PR DESCRIPTION
Add ADR 0032 (message-ownership) establishing that the application always owns messages at the engine/application boundary.

Document ownership guarantees on receiving-direction handler methods:
- `AggregateMessageHandler.HandleCommand`
- `AggregateRoot.ApplyEvent`
- `IntegrationMessageHandler.HandleCommand`
- `ProcessMessageHandler.HandleEvent`
- `ProcessMessageHandler.HandleTimeout`
- `ProjectionMessageHandler.HandleEvent`
- `EventObserver`

Closes #165