### PR TITLE
Add ADR-34: process root mutation

### DIFF
--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -55,9 +55,7 @@ func TestUntypedAggregateMessageHandler(t *testing.T) {
 			},
 		)
 	})
-}
 
-func TestAggregateMessageHandlerAdaptor(t *testing.T) {
 	inner := &aggregateHandlerStub{
 		routeID: "instance-001",
 	}
@@ -76,7 +74,7 @@ func TestAggregateMessageHandlerAdaptor(t *testing.T) {
 	t.Run("func New()", func(t *testing.T) {
 		t.Run("it returns the root from the wrapped handler", func(t *testing.T) {
 			got := adaptor.New()
-			expectType[aggregateRootStub](t, got)
+			expectType[*aggregateRootStub](t, got)
 		})
 	})
 
@@ -91,7 +89,7 @@ func TestAggregateMessageHandlerAdaptor(t *testing.T) {
 
 	t.Run("func HandleCommand()", func(t *testing.T) {
 		t.Run("it narrows the root type and delegates to the wrapped handler", func(t *testing.T) {
-			adaptor.HandleCommand(aggregateRootStub{}, nil, nil)
+			adaptor.HandleCommand(&aggregateRootStub{}, nil, nil)
 			if !inner.handleCalled {
 				t.Fatal("expected HandleCommand to be called on the wrapped handler")
 			}
@@ -112,8 +110,8 @@ type aggregateRootStub struct {
 	NoSnapshotBehavior
 }
 
-func (aggregateRootStub) AggregateInstanceDescription() string { return "" }
-func (aggregateRootStub) ApplyEvent(Event)                     {}
+func (*aggregateRootStub) AggregateInstanceDescription() string { return "" }
+func (*aggregateRootStub) ApplyEvent(Event)                     {}
 
 type aggregateHandlerStub struct {
 	configured   bool
@@ -121,14 +119,12 @@ type aggregateHandlerStub struct {
 	handleCalled bool
 }
 
-var _ AggregateMessageHandler[aggregateRootStub] = &aggregateHandlerStub{}
-
 func (h *aggregateHandlerStub) Configure(AggregateConfigurer) {
 	h.configured = true
 }
 
-func (h *aggregateHandlerStub) New() aggregateRootStub {
-	return aggregateRootStub{}
+func (h *aggregateHandlerStub) New() *aggregateRootStub {
+	return &aggregateRootStub{}
 }
 
 func (h *aggregateHandlerStub) RouteCommandToInstance(Command) string {
@@ -136,8 +132,8 @@ func (h *aggregateHandlerStub) RouteCommandToInstance(Command) string {
 }
 
 func (h *aggregateHandlerStub) HandleCommand(
-	_ aggregateRootStub,
-	_ AggregateCommandScope[aggregateRootStub],
+	_ *aggregateRootStub,
+	_ AggregateCommandScope[*aggregateRootStub],
 	_ Command,
 ) {
 	h.handleCalled = true

--- a/docs/adr/0034-process-root-mutation.md
+++ b/docs/adr/0034-process-root-mutation.md
@@ -48,8 +48,8 @@ mutation against the `mut` parameter.
 
 The engine may elide the call to `fn` in some circumstances — for example, when
 the root is a `StatelessProcessRoot` and persistence is known to be a
-no-op. Because `fn` is not guaranteed to execute, it must not perform any side
-effects beyond mutating `mut`. In particular:
+no-op. Because `fn` is not guaranteed to execute, it must not perform any
+side-effects beyond mutating `mut`. In particular:
 
 - It must not call any methods on `s`, the `ProcessScope`.
 - It must not use `r`, even for read-only purposes.

--- a/docs/adr/0034-process-root-mutation.md
+++ b/docs/adr/0034-process-root-mutation.md
@@ -1,0 +1,100 @@
+# 34. Process root mutation
+
+Date: 2026-05-03
+
+## Status
+
+Proposed
+
+> [!NOTE]
+> This decision has not yet been accepted and is subject to change.
+
+## Context
+
+A process message handler maintains a `ProcessRoot` for each active process
+instance, accumulating state across multiple event and timeout messages. The
+engine persists each instance's root between invocations — by marshaling it with
+`MarshalBinary()` after each successful `HandleEvent()` or `HandleTimeout()`
+call — so that later invocations start from the accumulated state rather than
+from scratch.
+
+Currently, the handler mutates the root directly. `HandleEvent()` and
+`HandleTimeout()` both receive the `ProcessRoot` and may update it freely by
+calling methods on it or assigning to its fields.
+
+This means the engine cannot determine whether a given invocation actually
+changed the root without resorting to a potentially expensive deep equality
+check against some snapshot of the previous state. The engine must marshal and
+persist the root after every successful invocation — even those that only
+executed commands, scheduled timeouts, or inspected state without making any
+changes.
+
+Aggregates do not have this problem; every call to `RecordEvent()` gives the
+engine an unambiguous signal that the aggregate instance's state has changed.
+
+## Decision
+
+We will add a `Mutate()` method to `ProcessScope`. It accepts a single
+callback that is passed a mutable reference to the root:
+
+```go
+Mutate(fn func(mut R))
+```
+
+The `ProcessRoot` parameter `r` of `HandleEvent()` and `HandleTimeout()` becomes
+read-only from the handler's perspective. Handlers may no longer mutate `r`
+directly; instead, they must call `Mutate()` with a callback that performs the
+mutation against the `mut` parameter.
+
+The engine may elide the call to `fn` in some circumstances — for example, when
+the root is a `StatelessProcessRoot` and persistence is known to be a
+no-op. Because `fn` is not guaranteed to execute, it must not perform any side
+effects beyond mutating `mut`. In particular:
+
+- It must not call any methods on `s`, the `ProcessScope`.
+- It must not use `r`, even for read-only purposes.
+
+Since the call to `fn` may be elided, all conditional logic — deciding whether
+and how to mutate — should be evaluated before calling `Mutate()`. The callback
+should express an unconditional change; however, it is acceptable for the net
+effect of `fn` to be a no-op — for example, setting a field to the value it
+already holds.
+
+The engine must ensure that `r` reflects the post-mutation state after `fn`
+returns, so that the handler can continue to read from it.
+
+`Mutate()` may be called more than once within a single `HandleEvent()` or
+`HandleTimeout()` invocation. Each call is an independent mutation window.
+
+Calling `Mutate()` after `End()` panics, mirroring the behavior of
+`ExecuteCommand()` and `ScheduleTimeout()`.
+
+### Dismissed alternatives
+
+We considered a zero-argument `s.Mutate()` — a dirty flag the handler sets after
+mutating `r` directly, as it does now. This would allow the engine to skip
+persisting the root when the flag is not set, but the mutation and the signal
+remain decoupled, which invites mistakes.
+
+## Consequences
+
+The engine gains a reliable signal for avoiding unnecessary persistence: if
+`Mutate()` was not called, the root does not need to be persisted for that
+invocation, though commands and timeout messages produced in the same scope are
+still dispatched. The engine also gains a natural observation point around each
+mutation — it can capture the root's state before and after the callback — which
+enables structured telemetry such as state-transition traces and audit logs.
+
+This is a breaking change to `ProcessScope`. Engine implementations must add
+`Mutate()` to their scope implementations, and application code must be updated
+to call `Mutate()` instead of mutating `r` directly.
+
+Existing handler code that mutates the root directly continues to compile, but
+violates the updated contract. `testkit` may detect such violations by comparing
+the root's serialized state before and after each invocation.
+
+The relationship between `r` and `mut` is unspecified — they may be clones or
+refer to the same memory. Because `r` is off-limits while `fn` is executing, the
+engine may safely pass `r` to `fn`.
+
+<!-- references -->

--- a/docs/adr/0034-process-root-mutation.md
+++ b/docs/adr/0034-process-root-mutation.md
@@ -4,10 +4,7 @@ Date: 2026-05-03
 
 ## Status
 
-Proposed
-
-> [!NOTE]
-> This decision has not yet been accepted and is subject to change.
+Accepted
 
 ## Context
 

--- a/docs/adr/0034-process-root-mutation.md
+++ b/docs/adr/0034-process-root-mutation.md
@@ -35,7 +35,7 @@ engine an unambiguous signal that the aggregate instance's state has changed.
 ## Decision
 
 We will add a `Mutate()` method to `ProcessScope`. It accepts a single
-callback that is passed a mutable reference to the root:
+callback that receives the root to mutate:
 
 ```go
 Mutate(fn func(mut R))
@@ -96,5 +96,11 @@ the root's serialized state before and after each invocation.
 The relationship between `r` and `mut` is unspecified — they may be clones or
 refer to the same memory. Because `r` is off-limits while `fn` is executing, the
 engine may safely pass `r` to `fn`.
+
+For mutations inside `fn` to be visible outside it, `R` must be a pointer type.
+This was already an implicit requirement — `UnmarshalBinary()` must mutate its
+receiver, which requires a pointer receiver, so any concrete `ProcessRoot`
+implementation is already a pointer in practice. This ADR strengthens that
+requirement.
 
 <!-- references -->

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,3 +44,4 @@ the ADR documents.
 * [31. Require retries for idempotency-keyed commands](0031-require-retries-for-idempotency-keyed-commands.md)
 * [32. Message ownership](0032-message-ownership.md)
 * [33. Generic aggregate and process handlers](0033-generic-aggregate-and-process-handlers.md)
+* [34. Process root mutation](0034-process-root-mutation.md)

--- a/process.go
+++ b/process.go
@@ -88,11 +88,14 @@ type ProcessMessageHandler[R ProcessRoot] interface {
 	// the state of the targeted instance after handling any prior [Event] or
 	// [Timeout] messages.
 	//
-	// The implementation may update r directly, execute [Command] messages,
-	// schedule [Timeout] messages, or end the process. It may query external
-	// data - such as the application's projections - but this isn't
+	// The implementation may change the instance's state, execute [Command]
+	// messages, schedule [Timeout] messages, or end the process. It may query
+	// external data - such as the application's projections - but this isn't
 	// recommended. Wherever possible, logic should depend solely on information
 	// within r, s, and e.
+	//
+	// The implementation must not modify r directly; use [ProcessScope].Mutate
+	// instead. The callback passed to Mutate must not use r or s.
 	//
 	// The engine atomically persists the state changes, events, and timeouts
 	// produced by exactly one successful invocation of this method for each
@@ -120,11 +123,14 @@ type ProcessMessageHandler[R ProcessRoot] interface {
 	// reflects the state of the targeted instance after handling any prior
 	// [Event] or [Timeout] messages.
 	//
-	// The implementation may update r directly, execute [Command] messages,
-	// schedule [Timeout] messages, or end the process. It may query external
-	// data - such as the application's projections - but this isn't
+	// The implementation may change the instance's state, execute [Command]
+	// messages, schedule [Timeout] messages, or end the process. It may query
+	// external data - such as the application's projections - but this isn't
 	// recommended. Wherever possible, logic should depend solely on information
 	// within r, s, and t.
+	//
+	// The implementation must not modify r directly; use [ProcessScope].Mutate
+	// instead. The callback passed to Mutate must not use r or s.
 	//
 	// The engine atomically persists the state changes, events, and timeouts
 	// produced by exactly one successful invocation of this method for each
@@ -224,6 +230,24 @@ type ProcessScope[R ProcessRoot] interface {
 	// When handling a [Timeout] message, it returns the ID of the instance that
 	// scheduled the timeout.
 	InstanceID() string
+
+	// Mutate changes the process instance's state by calling fn with the
+	// current root, making the state changes visible to the handler
+	// immediately.
+	//
+	// The callback must not call any methods on the scope.
+	//
+	// The engine may elide the call to fn - for example, when the root is a
+	// [StatelessProcessRoot]. Because fn may not execute, it must not perform
+	// side-effects beyond mutating the root.
+	//
+	// It is acceptable for the net effect of fn to be a no-op - for example,
+	// setting a field to the value it already holds.
+	//
+	// Mutate may be called more than once.
+	//
+	// This method panics if the process instance has ended.
+	Mutate(fn func(r R))
 
 	// End signals the end of a process.
 	//
@@ -395,7 +419,12 @@ func (a *untypedProcessMessageHandler[R]) HandleEvent(
 	s ProcessEventScope[ProcessRoot],
 	e Event,
 ) error {
-	return a.handler.HandleEvent(ctx, r.(R), s, e)
+	return a.handler.HandleEvent(
+		ctx,
+		r.(R),
+		untypedProcessEventScope[R]{s},
+		e,
+	)
 }
 
 func (a *untypedProcessMessageHandler[R]) HandleTimeout(
@@ -404,9 +433,38 @@ func (a *untypedProcessMessageHandler[R]) HandleTimeout(
 	s ProcessTimeoutScope[ProcessRoot],
 	t Timeout,
 ) error {
-	return a.handler.HandleTimeout(ctx, r.(R), s, t)
+	return a.handler.HandleTimeout(
+		ctx,
+		r.(R),
+		untypedProcessTimeoutScope[R]{s},
+		t,
+	)
 }
 
 func (a *untypedProcessMessageHandler[R]) UnwrapHandler() any {
 	return a.handler
+}
+
+// untypedProcessEventScope adapts a [ProcessEventScope][ProcessRoot] to
+// [ProcessEventScope][R] by narrowing the Mutate callback type.
+type untypedProcessEventScope[R ProcessRoot] struct {
+	ProcessEventScope[ProcessRoot]
+}
+
+func (a untypedProcessEventScope[R]) Mutate(fn func(R)) {
+	a.ProcessEventScope.Mutate(func(r ProcessRoot) {
+		fn(r.(R))
+	})
+}
+
+// untypedProcessTimeoutScope adapts a [ProcessTimeoutScope][ProcessRoot] to
+// [ProcessTimeoutScope][R] by narrowing the Mutate callback type.
+type untypedProcessTimeoutScope[R ProcessRoot] struct {
+	ProcessTimeoutScope[ProcessRoot]
+}
+
+func (a untypedProcessTimeoutScope[R]) Mutate(fn func(R)) {
+	a.ProcessTimeoutScope.Mutate(func(r ProcessRoot) {
+		fn(r.(R))
+	})
 }

--- a/process_test.go
+++ b/process_test.go
@@ -104,9 +104,7 @@ func TestUntypedProcessMessageHandler(t *testing.T) {
 			},
 		)
 	})
-}
 
-func TestProcessMessageHandlerAdaptor(t *testing.T) {
 	inner := &processHandlerStub{
 		routeID: "instance-001",
 		routeOK: true,
@@ -126,7 +124,7 @@ func TestProcessMessageHandlerAdaptor(t *testing.T) {
 	t.Run("func New()", func(t *testing.T) {
 		t.Run("it returns the root from the wrapped handler", func(t *testing.T) {
 			got := adaptor.New()
-			expectType[processRootStub](t, got)
+			expectType[*processRootStub](t, got)
 		})
 	})
 
@@ -147,13 +145,34 @@ func TestProcessMessageHandlerAdaptor(t *testing.T) {
 
 	t.Run("func HandleEvent()", func(t *testing.T) {
 		t.Run("it narrows the root type and delegates to the wrapped handler", func(t *testing.T) {
-			err := adaptor.HandleEvent(t.Context(), processRootStub{}, nil, nil)
+			err := adaptor.HandleEvent(t.Context(), &processRootStub{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if !inner.handleEventCalled {
 				t.Fatal("expected HandleEvent to be called on the wrapped handler")
 			}
+		})
+
+		t.Run("it narrows the Mutate() callback type", func(t *testing.T) {
+			root := &processRootStub{}
+			scope := &processEventScopeStub{root: root}
+
+			h := &processHandlerStub{
+				routeID: "x",
+				routeOK: true,
+				handleEventFunc: func(_ *processRootStub, s ProcessEventScope[*processRootStub]) {
+					s.Mutate(func(r *processRootStub) {
+						if r != root {
+							t.Fatalf("unexpected root: got %v, want %v", r, root)
+						}
+					})
+				},
+			}
+
+			expectType[ProcessHandlerRoute](t, ViaProcess(h)).
+				Handler().
+				HandleEvent(t.Context(), root, scope, nil)
 		})
 
 		t.Run("it panics if the root has an unexpected type", func(t *testing.T) {
@@ -168,13 +187,34 @@ func TestProcessMessageHandlerAdaptor(t *testing.T) {
 
 	t.Run("func HandleTimeout()", func(t *testing.T) {
 		t.Run("it narrows the root type and delegates to the wrapped handler", func(t *testing.T) {
-			err := adaptor.HandleTimeout(t.Context(), processRootStub{}, nil, nil)
+			err := adaptor.HandleTimeout(t.Context(), &processRootStub{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if !inner.handleTimeoutCalled {
 				t.Fatal("expected HandleTimeout to be called on the wrapped handler")
 			}
+		})
+
+		t.Run("it narrows the Mutate() callback type", func(t *testing.T) {
+			root := &processRootStub{}
+			scope := &processTimeoutScopeStub{root: root}
+
+			h := &processHandlerStub{
+				routeID: "x",
+				routeOK: true,
+				handleTimeoutFunc: func(_ *processRootStub, s ProcessTimeoutScope[*processRootStub]) {
+					s.Mutate(func(r *processRootStub) {
+						if r != root {
+							t.Fatalf("unexpected root: got %v, want %v", r, root)
+						}
+					})
+				},
+			}
+
+			expectType[ProcessHandlerRoute](t, ViaProcess(h)).
+				Handler().
+				HandleTimeout(t.Context(), root, scope, nil)
 		})
 
 		t.Run("it panics if the root has an unexpected type", func(t *testing.T) {
@@ -190,9 +230,9 @@ func TestProcessMessageHandlerAdaptor(t *testing.T) {
 
 type processRootStub struct{}
 
-func (processRootStub) ProcessInstanceDescription(bool) string { return "" }
-func (processRootStub) MarshalBinary() ([]byte, error)         { return nil, nil }
-func (processRootStub) UnmarshalBinary([]byte) error           { return nil }
+func (*processRootStub) ProcessInstanceDescription(bool) string { return "" }
+func (*processRootStub) MarshalBinary() ([]byte, error)         { return nil, nil }
+func (*processRootStub) UnmarshalBinary([]byte) error           { return nil }
 
 type processHandlerStub struct {
 	configured          bool
@@ -200,16 +240,16 @@ type processHandlerStub struct {
 	routeOK             bool
 	handleEventCalled   bool
 	handleTimeoutCalled bool
+	handleEventFunc     func(*processRootStub, ProcessEventScope[*processRootStub])
+	handleTimeoutFunc   func(*processRootStub, ProcessTimeoutScope[*processRootStub])
 }
-
-var _ ProcessMessageHandler[processRootStub] = &processHandlerStub{}
 
 func (h *processHandlerStub) Configure(ProcessConfigurer) {
 	h.configured = true
 }
 
-func (h *processHandlerStub) New() processRootStub {
-	return processRootStub{}
+func (h *processHandlerStub) New() *processRootStub {
+	return &processRootStub{}
 }
 
 func (h *processHandlerStub) RouteEventToInstance(
@@ -221,21 +261,27 @@ func (h *processHandlerStub) RouteEventToInstance(
 
 func (h *processHandlerStub) HandleEvent(
 	_ context.Context,
-	_ processRootStub,
-	_ ProcessEventScope[processRootStub],
+	r *processRootStub,
+	s ProcessEventScope[*processRootStub],
 	_ Event,
 ) error {
 	h.handleEventCalled = true
+	if h.handleEventFunc != nil {
+		h.handleEventFunc(r, s)
+	}
 	return nil
 }
 
 func (h *processHandlerStub) HandleTimeout(
 	_ context.Context,
-	_ processRootStub,
-	_ ProcessTimeoutScope[processRootStub],
+	r *processRootStub,
+	s ProcessTimeoutScope[*processRootStub],
 	_ Timeout,
 ) error {
 	h.handleTimeoutCalled = true
+	if h.handleTimeoutFunc != nil {
+		h.handleTimeoutFunc(r, s)
+	}
 	return nil
 }
 
@@ -244,3 +290,17 @@ func init() {
 	assertIsComparable(NoTimeoutMessagesBehavior[ProcessRoot]{})
 	assertIsComparable(StatelessProcessRoot{})
 }
+
+type processEventScopeStub struct {
+	ProcessEventScope[ProcessRoot]
+	root ProcessRoot
+}
+
+func (s *processEventScopeStub) Mutate(fn func(ProcessRoot)) { fn(s.root) }
+
+type processTimeoutScopeStub struct {
+	ProcessTimeoutScope[ProcessRoot]
+	root ProcessRoot
+}
+
+func (s *processTimeoutScopeStub) Mutate(fn func(ProcessRoot)) { fn(s.root) }


### PR DESCRIPTION
Adds ADR-34, which documents the decision to add a `Mutate()` method to `ProcessScope`, and implements the change.

The new method accepts a callback `func(mut R)` that the handler uses to mutate the process root. This gives the engine an unambiguous signal that the root has changed, allowing it to skip persisting the root when `Mutate()` was not called during an invocation.

Closes #209.