### PR TITLE
Rename "timeout" to "deadline" across the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ The format is based on [Keep a Changelog], and this project adheres to
 [bc]: https://github.com/dogmatiq/.github/blob/main/VERSIONING.md#changelogs
 [engine bc]: https://github.com/dogmatiq/.github/blob/main/VERSIONING.md#changelogs
 
+## [Unreleased]
+
+### Changed
+
+- **[BC]** Renamed `Timeout` interface to `Deadline`
+- **[BC]** Renamed `TimeoutValidationScope` interface to
+  `DeadlineValidationScope`
+- **[BC]** Renamed `ProcessMessageHandler.HandleTimeout()` method to
+  `HandleDeadline()`
+- **[BC]** Renamed `ProcessTimeoutScope` interface to `ProcessDeadlineScope`
+- **[BC]** Renamed `ProcessScope.ScheduleTimeout()` method to
+  `ScheduleDeadline()`
+- **[BC]** Renamed `NoTimeoutMessagesBehavior` type to
+  `NoDeadlineMessagesBehavior`
+- **[BC]** Renamed `SchedulesTimeout()` function to `SchedulesDeadline()`
+- **[BC]** Renamed `SchedulesTimeoutRoute` type to `SchedulesDeadlineRoute`
+- **[BC]** Renamed `SchedulesTimeoutOption` interface to
+  `SchedulesDeadlineOption`
+- **[BC]** Renamed `RegisterTimeout()` function to `RegisterDeadline()`
+- **[BC]** Renamed `RegisterTimeoutOption` interface to
+  `RegisterDeadlineOption`
+
 ## [0.23.0] - 2026-04-25
 
 This release genericizes `AggregateMessageHandler` and

--- a/docs/adr/0035-rename-timeout-to-deadline.md
+++ b/docs/adr/0035-rename-timeout-to-deadline.md
@@ -26,14 +26,14 @@ In practice, the term has three problems:
    `time.Duration`.
 
 2. "Timeout" carries connotations of failure or abandonment — an operation that
-   ran too long. While some Dogma uses fit this mold (e.g. canceling an
+   ran too long. While some Dogma uses fit this mold (for example, canceling an
    unpaid order), many do not. A process that schedules a reminder for 30 days
    before a contract renewal isn't "timing out" — it's reaching a deadline.
 
 3. When discussing process behavior with domain experts, "deadline" maps more
    naturally to business language. "When does this invoice become overdue? The
-   deadline for payment is January 7th" is a conversation that works. "The
-   timeout for payment is January 7th" is not.
+   deadline for payment is January seventh" is a conversation that works. "The
+   timeout for payment is January seventh" is not.
 
 ## Decision
 
@@ -84,8 +84,9 @@ document the rename under its own release.
 
 ## Consequences
 
-Every downstream consumer of the Dogma API — engine implementations, testkit,
-enginekit, and application code — will need a corresponding rename. Those
+Every downstream consumer of the Dogma API — engine implementations,
+`testkit`, `enginekit`, and application code — will need a corresponding
+rename. Those
 changes are planned separately, after this rename lands.
 
 The glossary gains a new "deadline" entry replacing "timeout", and "process

--- a/docs/adr/0035-rename-timeout-to-deadline.md
+++ b/docs/adr/0035-rename-timeout-to-deadline.md
@@ -42,19 +42,19 @@ This is a purely terminological change — it has no effect on runtime behavior.
 
 The complete set of symbol renames is:
 
-| Old                           | New                            |
-| ----------------------------- | ------------------------------ |
-| `Timeout`                     | `Deadline`                     |
-| `TimeoutValidationScope`      | `DeadlineValidationScope`      |
-| `HandleTimeout()`             | `HandleDeadline()`             |
-| `ScheduleTimeout()`           | `ScheduleDeadline()`           |
-| `ProcessTimeoutScope`         | `ProcessDeadlineScope`         |
-| `NoTimeoutMessagesBehavior`   | `NoDeadlineMessagesBehavior`   |
-| `SchedulesTimeout()`          | `SchedulesDeadline()`          |
-| `SchedulesTimeoutRoute`       | `SchedulesDeadlineRoute`       |
-| `SchedulesTimeoutOption`      | `SchedulesDeadlineOption`      |
-| `RegisterTimeout()`           | `RegisterDeadline()`           |
-| `RegisterTimeoutOption`       | `RegisterDeadlineOption`       |
+| Old                         | New                          |
+| --------------------------- | ---------------------------- |
+| `Timeout`                   | `Deadline`                   |
+| `TimeoutValidationScope`    | `DeadlineValidationScope`    |
+| `HandleTimeout()`           | `HandleDeadline()`           |
+| `ScheduleTimeout()`         | `ScheduleDeadline()`         |
+| `ProcessTimeoutScope`       | `ProcessDeadlineScope`       |
+| `NoTimeoutMessagesBehavior` | `NoDeadlineMessagesBehavior` |
+| `SchedulesTimeout()`        | `SchedulesDeadline()`        |
+| `SchedulesTimeoutRoute`     | `SchedulesDeadlineRoute`     |
+| `SchedulesTimeoutOption`    | `SchedulesDeadlineOption`    |
+| `RegisterTimeout()`         | `RegisterDeadline()`         |
+| `RegisterTimeoutOption`     | `RegisterDeadlineOption`     |
 
 We considered `SetDeadline` instead of `ScheduleDeadline` for the
 `ProcessScope` method. `SetDeadline` is more idiomatic English and matches
@@ -79,15 +79,12 @@ In addition to the symbol renames, we will adopt these conventions for how
 ### Historical records
 
 Existing ADRs and CHANGELOG entries are left unchanged. They are point-in-time
-records that used the vocabulary of their era. A new CHANGELOG entry will
-document the rename under its own release.
+records that used the vocabulary of their era.
 
 ## Consequences
 
-Every downstream consumer of the Dogma API — engine implementations,
-`testkit`, `enginekit`, and application code — will need a corresponding
-rename. Those
-changes are planned separately, after this rename lands.
+Every downstream consumer of the Dogma API — engine implementations, `testkit`,
+`enginekit`, and application code — will need a corresponding rename.
 
 The glossary gains a new "deadline" entry replacing "timeout", and "process
 deadline scope" replacing "process timeout scope".

--- a/docs/adr/0035-rename-timeout-to-deadline.md
+++ b/docs/adr/0035-rename-timeout-to-deadline.md
@@ -1,0 +1,96 @@
+# 35. Rename timeout to deadline
+
+Date: 2026-05-04
+
+## Status
+
+Proposed
+
+> [!NOTE]
+> This decision has not yet been accepted and is subject to change.
+
+## Context
+
+Dogma uses the term "timeout" for messages that notify a process handler that a
+specific point in time has been reached. The term was adopted from [NServiceBus]
+early in the project's history because no better alternative came to mind at the
+time.
+
+In practice, the term has three problems:
+
+1. In Go, "deadline" is the established term for a specific wall-clock time at
+   which something should happen. The `context` package and `net.Conn` both use
+   "deadline" for this purpose, while "timeout" refers to a duration after
+   which an operation is abandoned. Dogma's "timeout" messages behave like Go
+   deadlines — they are scheduled for a specific `time.Time`, not after a
+   `time.Duration`.
+
+2. "Timeout" carries connotations of failure or abandonment — an operation that
+   ran too long. While some Dogma uses fit this mold (e.g. canceling an
+   unpaid order), many do not. A process that schedules a reminder for 30 days
+   before a contract renewal isn't "timing out" — it's reaching a deadline.
+
+3. When discussing process behavior with domain experts, "deadline" maps more
+   naturally to business language. "When does this invoice become overdue? The
+   deadline for payment is January 7th" is a conversation that works. "The
+   timeout for payment is January 7th" is not.
+
+## Decision
+
+We will rename all API symbols and documentation from "timeout" to "deadline".
+This is a purely terminological change — it has no effect on runtime behavior.
+
+The complete set of symbol renames is:
+
+| Old                           | New                            |
+| ----------------------------- | ------------------------------ |
+| `Timeout`                     | `Deadline`                     |
+| `TimeoutValidationScope`      | `DeadlineValidationScope`      |
+| `HandleTimeout()`             | `HandleDeadline()`             |
+| `ScheduleTimeout()`           | `ScheduleDeadline()`           |
+| `ProcessTimeoutScope`         | `ProcessDeadlineScope`         |
+| `NoTimeoutMessagesBehavior`   | `NoDeadlineMessagesBehavior`   |
+| `SchedulesTimeout()`          | `SchedulesDeadline()`          |
+| `SchedulesTimeoutRoute`       | `SchedulesDeadlineRoute`       |
+| `SchedulesTimeoutOption`      | `SchedulesDeadlineOption`      |
+| `RegisterTimeout()`           | `RegisterDeadline()`           |
+| `RegisterTimeoutOption`       | `RegisterDeadlineOption`       |
+
+We considered `SetDeadline` instead of `ScheduleDeadline` for the
+`ProcessScope` method. `SetDeadline` is more idiomatic English and matches
+Go's `net.Conn.SetDeadline`. However, Go's `SetDeadline` overwrites the
+previous value, whereas Dogma's method adds a new pending message — each call
+produces an independent delivery. `ScheduleDeadline` preserves the existing
+verb, reinforces the message-delivery semantics, and keeps the rename
+mechanical.
+
+### Documentation conventions
+
+In addition to the symbol renames, we will adopt these conventions for how
+"deadline" is used in prose:
+
+- Deadlines are "reached", not "occurred" or "elapsed".
+- Deadlines are scheduled "for" a time, not "to occur at" a time.
+- Use "deadline" alone when the verb applies to the concept itself: schedule a
+  deadline, reach a deadline, cancel a deadline.
+- Use "deadline message" when the verb applies to the message artifact: deliver
+  a deadline message, handle a deadline message, persist a deadline message.
+
+### Historical records
+
+Existing ADRs and CHANGELOG entries are left unchanged. They are point-in-time
+records that used the vocabulary of their era. A new CHANGELOG entry will
+document the rename under its own release.
+
+## Consequences
+
+Every downstream consumer of the Dogma API — engine implementations, testkit,
+enginekit, and application code — will need a corresponding rename. Those
+changes are planned separately, after this rename lands.
+
+The glossary gains a new "deadline" entry replacing "timeout", and "process
+deadline scope" replacing "process timeout scope".
+
+<!-- references -->
+
+[NServiceBus]: https://docs.particular.net/nservicebus/sagas/timeouts

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,3 +45,4 @@ the ADR documents.
 * [32. Message ownership](0032-message-ownership.md)
 * [33. Generic aggregate and process handlers](0033-generic-aggregate-and-process-handlers.md)
 * [34. Process root mutation](0034-process-root-mutation.md)
+* [35. Rename timeout to deadline](0035-rename-timeout-to-deadline.md)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -39,8 +39,8 @@ Dogma defines three **kinds** of message:
 
   For example, _added 10 widgets to Alex's shopping cart_.
 
-- A **timeout** message is a delayed notification — it tells your application
-  that some relevant period of time has elapsed.
+- A **deadline** message is a scheduled notification — it tells your application
+  that a domain-relevant point in time has been reached.
 
   <!-- vale Google.Passive = NO -->
 
@@ -50,7 +50,7 @@ Dogma defines three **kinds** of message:
 
 Every distinct action — such as "add item to cart" or "complete purchase" —
 corresponds to a different **message type**, each represented by a Go type that
-implements one of the [`Command`], [`Event`], or [`Timeout`] interfaces.
+implements one of the [`Command`], [`Event`], or [`Deadline`] interfaces.
 
 > [!IMPORTANT]
 > Messages must not rely on information that may be unavailable when they're
@@ -75,7 +75,7 @@ Dogma defines four types of handler:
 
 - A **process message handler** coordinates a workflow that involves multiple
   aggregate instances or time-sensitive logic. It handles event messages by
-  executing commands and scheduling timeout messages to drive the workflow
+  executing commands and scheduling deadline messages to drive the workflow
   forward. Like aggregates, each process can have many instances.
 
 - A **projection message handler** builds a view of the application's state by
@@ -220,7 +220,7 @@ explore the following resources:
 [`IntegrationMessageHandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma#IntegrationMessageHandler
 [`ProcessMessageHandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProcessMessageHandler
 [`ProjectionMessageHandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProjectionMessageHandler
-[`Timeout`]: https://pkg.go.dev/github.com/dogmatiq/dogma#Timeout
+[`Deadline`]: https://pkg.go.dev/github.com/dogmatiq/dogma#Deadline
 
 <!-- external references -->
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -114,6 +114,13 @@ core concepts and behavior of the business domain it supports.
 See [domain-driven design](https://en.wikipedia.org/wiki/Domain-driven_design)
 for more information.
 
+### Deadline
+
+A [message] that notifies a [process] that a domain-relevant point in time has
+been reached.
+
+See [`dogma.Deadline`].
+
 ## E
 
 ### Engine
@@ -210,7 +217,7 @@ See:
 
 - [command]
 - [event]
-- [timeout]
+- [deadline]
 - [`dogma.Message`]
 
 ### Message handler
@@ -228,7 +235,7 @@ See:
 ### Message kind
 
 The category of a [message] that defines its role in the application, one of
-[command], [event], or [timeout].
+[command], [event], or [deadline].
 
 ### Message route
 
@@ -239,7 +246,7 @@ See:
 
 - [`dogma.HandlesCommand()`] and [`dogma.ExecutesCommand()`]
 - [`dogma.HandlesEvent()`] and [`dogma.RecordsEvent()`]
-- [`dogma.SchedulesTimeout()`]
+- [`dogma.SchedulesDeadline()`]
 
 ### Message type
 
@@ -267,7 +274,7 @@ logic.
 ### Process event scope
 
 The [handler scope] in which a [process message handler] handles an [event]
-message by updating [state], executing [command] messages, or scheduling [timeout]
+message by updating [state], executing [command] messages, or scheduling [deadline]
 messages to advance the [process instance]'s workflow.
 
 See [`dogma.ProcessEventScope`].
@@ -280,7 +287,7 @@ A unique occurrence of a [process] within an [application], encapsulating the
 ### Process message handler
 
 A [message handler] that orchestrates a [process] by handling [event] messages,
-executing [command] messages and scheduling [timeout] messages.
+executing [command] messages and scheduling [deadline] messages.
 
 See [`dogma.ProcessMessageHandler`].
 
@@ -291,14 +298,14 @@ Named by analogy to [aggregate root].
 
 See [`dogma.ProcessRoot`].
 
-### Process timeout scope
+### Process deadline scope
 
-The [handler scope] in which a [process message handler] handles a [timeout]
+The [handler scope] in which a [process message handler] handles a [deadline]
 message at its scheduled time, by updating [state], executing [command]
-messages, or scheduling more [timeout] messages to advance the [process instance]'s
+messages, or scheduling more [deadline] messages to advance the [process instance]'s
 workflow.
 
-See [`dogma.ProcessTimeoutScope`].
+See [`dogma.ProcessDeadlineScope`].
 
 ### Projection
 
@@ -396,13 +403,6 @@ A Go module that provides high-level tools for testing Dogma [applications].
 
 See [`dogmatiq/testkit`].
 
-### Timeout
-
-A [message] that describes an action that a [process] should take at a specific
-time in the future.
-
-See [`dogma.Timeout`].
-
 ## V
 
 ### Validation scope
@@ -462,7 +462,7 @@ See [process].
 [state]: #state
 [stateful]: #stateful
 [stateless]: #stateless
-[timeout]: #timeout
+[deadline]: #deadline
 
 <!-- go modules -->
 
@@ -493,14 +493,14 @@ See [process].
 [`dogma.ProcessEventScope`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProcessEventScope
 [`dogma.ProcessMessageHandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProcessMessageHandler
 [`dogma.ProcessRoot`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProcessRoot
-[`dogma.ProcessTimeoutScope`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProcessTimeoutScope
+[`dogma.ProcessDeadlineScope`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProcessDeadlineScope
 [`dogma.ProjectionCompactScope`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProjectionCompactScope
 [`dogma.ProjectionConfigurer`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProjectionConfigurer
 [`dogma.ProjectionEventScope`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProjectionEventScope
 [`dogma.ProjectionMessageHandler`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ProjectionMessageHandler
 [`dogma.RecordsEvent()`]: https://pkg.go.dev/github.com/dogmatiq/dogma#RecordsEvent
-[`dogma.SchedulesTimeout()`]: https://pkg.go.dev/github.com/dogmatiq/dogma#SchedulesTimeout
-[`dogma.Timeout`]: https://pkg.go.dev/github.com/dogmatiq/dogma#Timeout
+[`dogma.SchedulesDeadline()`]: https://pkg.go.dev/github.com/dogmatiq/dogma#SchedulesDeadline
+[`dogma.Deadline`]: https://pkg.go.dev/github.com/dogmatiq/dogma#Deadline
 [`dogma.ViaAggregate()`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ViaAggregate
 [`dogma.ViaIntegration()`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ViaIntegration
 [`dogma.ViaProcess()`]: https://pkg.go.dev/github.com/dogmatiq/dogma#ViaProcess

--- a/docs/handler-type-comparison.md
+++ b/docs/handler-type-comparison.md
@@ -14,7 +14,7 @@ If you're new to Dogma, start by familiarising yourself with the key [concepts].
 | ---------------------- | :-------: | :------: | :---------: | :----------: |
 | Command messages       |     ↓     |    ↑     |      ↓      |              |
 | Event messages         |     ↑     |    ↓     |      ↑      |      ↓       |
-| Timeout messages       |           |    ⇅     |             |              |
+| Deadline messages      |           |    ⇅     |             |              |
 | [State]                |     ✓     |    ✓     |             |              |
 | [External data access] |           |    ~     |      ✓      |      ✓       |
 | [Isolation boundary]   | instance  | instance |   command   | event-stream |

--- a/handler.go
+++ b/handler.go
@@ -62,7 +62,7 @@ type DisableOption interface {
 //
 //   - [AggregateCommandScope]
 //   - [ProcessEventScope]
-//   - [ProcessTimeoutScope]
+//   - [ProcessDeadlineScope]
 //   - [IntegrationCommandScope]
 //   - [ProjectionEventScope]
 //   - [ProjectionCompactScope]

--- a/message.go
+++ b/message.go
@@ -3,11 +3,11 @@ package dogma
 import "time"
 
 // A Message is an application-defined unit of data that describes a [Command],
-// [Event], or [Timeout] within a message-based application.
+// [Event], or [Deadline] within a message-based application.
 
 // A Message describes something an [Application] can do or has done.
 //
-// Each message type implements either [Command], [Event], or [Timeout].
+// Each message type implements either [Command], [Event], or [Deadline].
 //
 // Implementations must be safe for concurrent use by multiple goroutines.
 type Message interface {
@@ -28,9 +28,9 @@ type Message interface {
 	// Descriptions of [Event] messages should use past tense. For example:
 	// "added 10 widgets to Alex's shopping cart".
 	//
-	// Descriptions of [Timeout] messages should read as though the timeout has
-	// just elapsed. For example: "Alex's cart is now inactive" or "24 hours
-	// elapsed since first item added to Alex's cart".
+	// Descriptions of [Deadline] messages should read as though the deadline
+	// has just been reached. For example: "Alex's cart is now inactive" or
+	// "24 hours elapsed since first item added to Alex's cart".
 	//
 	// Be wary of assuming a specific actor if the message doesn't explicitly
 	// encode that information. For example, prefer "Alex's purchase completed"
@@ -62,7 +62,7 @@ type unexpectedMessage struct{}
 //
 //   - [CommandValidationScope]
 //   - [EventValidationScope]
-//   - [TimeoutValidationScope]
+//   - [DeadlineValidationScope]
 type MessageValidationScope interface {
 	// IsNew returns true when a handler or [CommandExecutor] is creating a new
 	// message, or false when the engine is re-validating a message that it has
@@ -134,32 +134,35 @@ type EventValidationScope interface {
 	RecordedAt() time.Time
 }
 
-// A Timeout is a [Message] that notifies an [Application], specifically a
-// [ProcessMessageHandler] that some domain-relevant period of time has elapsed.
-type Timeout interface {
+// A Deadline is a [Message] that notifies an [Application], specifically a
+// [ProcessMessageHandler], that a domain-relevant point in time has been
+// reached.
+type Deadline interface {
 	Message
 
 	// Validate returns a non-nil error if the message isn't well-formed.
 	//
-	// A timeout is well-formed if all required information is present and
+	// A deadline is well-formed if all required information is present and
 	// correctly encoded such that it accurately represents an action that can
 	// occur within the process, if current state permits.
 	//
 	// Validation requirements may change over time. Use the
-	// [TimeoutValidationScope] to access context that may affect the strictness
+	// [DeadlineValidationScope] to access context that may affect the strictness
 	// or criteria of the validation logic.
-	Validate(TimeoutValidationScope) error
+	Validate(DeadlineValidationScope) error
 }
 
-// TimeoutValidationScope provides context during [Timeout] validation.
+// DeadlineValidationScope provides context during [Deadline] validation.
 //
-// The engine provides the implementation to [Timeout].Validate.
-type TimeoutValidationScope interface {
+// The engine provides the implementation to [Deadline].Validate.
+type DeadlineValidationScope interface {
 	MessageValidationScope
 
-	// ScheduledAt returns the time at which the handler scheduled the timeout.
+	// ScheduledAt returns the time at which
+	// [ProcessScope].ScheduleDeadline was called.
 	ScheduledAt() time.Time
 
-	// ScheduledFor returns the time at which the timeout occurs.
+	// ScheduledFor returns the time at which the deadline message is to be
+	// delivered.
 	ScheduledFor() time.Time
 }

--- a/messageroute.go
+++ b/messageroute.go
@@ -62,18 +62,18 @@ func HandlesEvent[T Event](...HandlesEventOption) interface {
 	return HandlesEventRoute{typ: registeredMessageTypeFor[T]()}
 }
 
-// SchedulesTimeout configures a [ProcessMessageHandler] as a scheduler of
-// [Timeout] messages of type T.
+// SchedulesDeadline configures a [ProcessMessageHandler] as a scheduler of
+// [Deadline] messages of type T.
 //
-// It panics if T isn't in the message registry, see [RegisterTimeout].
+// It panics if T isn't in the message registry, see [RegisterDeadline].
 //
 // Pass the returned [MessageRoute] to [ProcessConfigurer].Routes.
 //
 // The application may have multiple handlers that schedule T.
-func SchedulesTimeout[T Timeout](...SchedulesTimeoutOption) interface {
+func SchedulesDeadline[T Deadline](...SchedulesDeadlineOption) interface {
 	ProcessRoute
 } {
-	return SchedulesTimeoutRoute{typ: registeredMessageTypeFor[T]()}
+	return SchedulesDeadlineRoute{typ: registeredMessageTypeFor[T]()}
 }
 
 type (
@@ -120,11 +120,11 @@ type (
 		typ RegisteredMessageType
 	}
 
-	// SchedulesTimeoutRoute is a [HandlerRoute] that represents a handler's
-	// ability to schedule [Timeout] messages of a specific type.
+	// SchedulesDeadlineRoute is a [HandlerRoute] that represents a handler's
+	// ability to schedule [Deadline] messages of a specific type.
 	//
-	// Use [SchedulesTimeout] to construct values of this type.
-	SchedulesTimeoutRoute struct {
+	// Use [SchedulesDeadline] to construct values of this type.
+	SchedulesDeadlineRoute struct {
 		nocmp
 		typ RegisteredMessageType
 	}
@@ -163,12 +163,12 @@ type (
 		futureRecordsEventOption()
 	}
 
-	// SchedulesTimeoutOption is an option that modifies the behavior of
-	// [SchedulesTimeout].
+	// SchedulesDeadlineOption is an option that modifies the behavior of
+	// [SchedulesDeadline].
 	//
 	// This type exists for forward-compatibility.
-	SchedulesTimeoutOption interface {
-		futureSchedulesTimeoutOption()
+	SchedulesDeadlineOption interface {
+		futureSchedulesDeadlineOption()
 	}
 )
 
@@ -193,6 +193,6 @@ func (r RecordsEventRoute) Type() RegisteredMessageType {
 }
 
 // Type returns the [RegisteredMessageType] for r.
-func (r SchedulesTimeoutRoute) Type() RegisteredMessageType {
+func (r SchedulesDeadlineRoute) Type() RegisteredMessageType {
 	return r.typ
 }

--- a/messageroute_nocoverage.go
+++ b/messageroute_nocoverage.go
@@ -1,7 +1,7 @@
 package dogma
 
-func (HandlesCommandRoute) isMessageRoute()   {}
-func (ExecutesCommandRoute) isMessageRoute()  {}
-func (HandlesEventRoute) isMessageRoute()     {}
-func (RecordsEventRoute) isMessageRoute()     {}
-func (SchedulesTimeoutRoute) isMessageRoute() {}
+func (HandlesCommandRoute) isMessageRoute()    {}
+func (ExecutesCommandRoute) isMessageRoute()   {}
+func (HandlesEventRoute) isMessageRoute()      {}
+func (RecordsEventRoute) isMessageRoute()      {}
+func (SchedulesDeadlineRoute) isMessageRoute() {}

--- a/messageroute_test.go
+++ b/messageroute_test.go
@@ -119,13 +119,13 @@ func TestRecordsEvent(t *testing.T) {
 	})
 }
 
-func TestSchedulesTimeout(t *testing.T) {
+func TestSchedulesDeadline(t *testing.T) {
 	t.Run("it returns a route containing the registered message type", func(t *testing.T) {
-		type T struct{ Timeout }
-		RegisterTimeout[*T]("e11b5a92-e1ab-4a16-841a-9286b4e4d12f")
+		type T struct{ Deadline }
+		RegisterDeadline[*T]("e11b5a92-e1ab-4a16-841a-9286b4e4d12f")
 
-		r := SchedulesTimeout[*T]()
-		expectType[SchedulesTimeoutRoute](t, r)
+		r := SchedulesDeadline[*T]()
+		expectType[SchedulesDeadlineRoute](t, r)
 
 		got := r.Type().GoType()
 		want := reflect.TypeFor[*T]()
@@ -140,8 +140,8 @@ func TestSchedulesTimeout(t *testing.T) {
 			t,
 			"*github.com/dogmatiq/dogma_test.T is not in the message type registry",
 			func() {
-				type T struct{ Timeout }
-				SchedulesTimeout[*T]()
+				type T struct{ Deadline }
+				SchedulesDeadline[*T]()
 			},
 		)
 	})

--- a/messagetyperegistry.go
+++ b/messagetyperegistry.go
@@ -60,35 +60,35 @@ type RegisterEventOption interface {
 	futureRegisterEventOption()
 }
 
-// RegisterTimeout adds a [Timeout] message type to the Dogma message registry,
-// making it eligible for use with [SchedulesTimeout].
+// RegisterDeadline adds a [Deadline] message type to the Dogma message
+// registry, making it eligible for use with [SchedulesDeadline].
 //
 // id uniquely identifies the message type. The value must be a canonical RFC
 // 9562 UUID string, such as "65f9620a-65c1-434e-8292-60cd7938c4de", and is
 // case-insensitive. The engine uses the ID to associate message data with the
 // correct Go type.
-func RegisterTimeout[
+func RegisterDeadline[
 	T interface {
 		*E
-		Timeout
+		Deadline
 	},
 	E any, // E is the "element" type of the pointer type T.
-](id string, _ ...RegisterTimeoutOption) {
-	registerMessageType[Timeout, T](id)
+](id string, _ ...RegisterDeadlineOption) {
+	registerMessageType[Deadline, T](id)
 }
 
-// RegisterTimeoutOption is an option that modifies the behavior of
-// [RegisterTimeout].
+// RegisterDeadlineOption is an option that modifies the behavior of
+// [RegisterDeadline].
 //
 // This type exists for forward-compatibility.
-type RegisterTimeoutOption interface {
-	futureRegisterTimeoutOption()
+type RegisterDeadlineOption interface {
+	futureRegisterDeadlineOption()
 }
 
 // RegisteredMessageType contains information about an implementation of [Command],
-// [Event], or [Timeout] that's in Dogma's message registry.
+// [Event], or [Deadline] that's in Dogma's message registry.
 //
-// Use [RegisterCommand], [RegisterEvent], or [RegisterTimeout] to add messages
+// Use [RegisterCommand], [RegisterEvent], or [RegisterDeadline] to add messages
 // to the registry.
 type RegisteredMessageType struct {
 	nocmp
@@ -187,7 +187,7 @@ func RegisteredMessageTypeByID(id string) (t RegisteredMessageType, ok bool) {
 // RegisteredMessageTypes returns an iterator that yields information about each
 // message in the Dogma message registry.
 //
-// Use [RegisterCommand], [RegisterEvent], or [RegisterTimeout] to add messages
+// Use [RegisterCommand], [RegisterEvent], or [RegisterDeadline] to add messages
 // to the registry.
 func RegisteredMessageTypes() iter.Seq[RegisteredMessageType] {
 	return func(yield func(RegisteredMessageType) bool) {
@@ -211,7 +211,7 @@ type messageTypes struct {
 }
 
 // messageTypeRegistry is a global registry of types that implement [Command],
-// [Event], and [Timeout].
+// [Event], and [Deadline].
 //
 // The messageTypes value is immutable. Every addition to the registry creates a
 // new messageTypes value that atomically replaces the old value. The registry

--- a/messagetyperegistry.go
+++ b/messagetyperegistry.go
@@ -35,7 +35,7 @@ type RegisterCommandOption interface {
 	futureRegisterCommandOption()
 }
 
-// RegisterEvent adds a [Event] message type to the Dogma message registry,
+// RegisterEvent adds an [Event] message type to the Dogma message registry,
 // making it eligible for use with [HandlesEvent] and [RecordsEvent].
 //
 // id uniquely identifies the message type. The value must be a canonical RFC

--- a/messagetyperegistry.go
+++ b/messagetyperegistry.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 )
 
-// RegisterCommand adds a [Command] message type to Dogma's message registry,
+// RegisterCommand adds a [Command] message type to the Dogma message registry,
 // making it eligible for use with [HandlesCommand] and [ExecutesCommand].
 //
 // id uniquely identifies the message type. The value must be a canonical RFC
@@ -35,8 +35,8 @@ type RegisterCommandOption interface {
 	futureRegisterCommandOption()
 }
 
-// RegisterEvent adds a [Event] message type to Dogma's message registry, making
-// it eligible for use with [HandlesEvent] and [RecordsEvent].
+// RegisterEvent adds a [Event] message type to the Dogma message registry,
+// making it eligible for use with [HandlesEvent] and [RecordsEvent].
 //
 // id uniquely identifies the message type. The value must be a canonical RFC
 // 9562 UUID string, such as "65f9620a-65c1-434e-8292-60cd7938c4de", and is

--- a/messagetyperegistry_test.go
+++ b/messagetyperegistry_test.go
@@ -110,11 +110,11 @@ func TestRegisteredMessageTypes(t *testing.T) {
 	t.Run("yields the registered message types", func(t *testing.T) {
 		type T struct{ Command }
 		type U struct{ Event }
-		type V struct{ Timeout }
+		type V struct{ Deadline }
 
 		RegisterCommand[*T]("b3160ff8-f19a-4f79-b81c-0551c99aeac2")
 		RegisterEvent[*U]("c3f856ba-0519-4335-ad84-313aa0fedc5e")
-		RegisterTimeout[*V]("8ab13db4-33ff-4dde-862c-7c94a0477231")
+		RegisterDeadline[*V]("8ab13db4-33ff-4dde-862c-7c94a0477231")
 
 		var yieldedT, yieldedU, yieldedV bool
 
@@ -138,7 +138,7 @@ func TestRegisteredMessageTypes(t *testing.T) {
 		}
 
 		if !yieldedV {
-			t.Fatal("timeout type was not yielded")
+			t.Fatal("deadline type was not yielded")
 		}
 	})
 
@@ -172,13 +172,13 @@ func TestMessageTypeRegistration(t *testing.T) {
 
 	t.Run("failure conditions", func(t *testing.T) {
 		cases := []struct {
-			Name         string
-			CommandError string
-			CommandFunc  func()
-			EventError   string
-			EventFunc    func()
-			TimeoutError string
-			TimeoutFunc  func()
+			Name          string
+			CommandError  string
+			CommandFunc   func()
+			EventError    string
+			EventFunc     func()
+			DeadlineError string
+			DeadlineFunc  func()
 		}{
 			{
 				"duplicate registration",
@@ -196,9 +196,9 @@ func TestMessageTypeRegistration(t *testing.T) {
 				},
 				`cannot register *github.com/dogmatiq/dogma_test.T: it is already registered`,
 				func() {
-					type T struct{ Timeout }
-					RegisterTimeout[*T]("6dfb9656-92b4-4cef-b51d-f808bf6403b2")
-					RegisterTimeout[*T]("6dfb9656-92b4-4cef-b51d-f808bf6403b2")
+					type T struct{ Deadline }
+					RegisterDeadline[*T]("6dfb9656-92b4-4cef-b51d-f808bf6403b2")
+					RegisterDeadline[*T]("6dfb9656-92b4-4cef-b51d-f808bf6403b2")
 				},
 			},
 			{
@@ -217,9 +217,9 @@ func TestMessageTypeRegistration(t *testing.T) {
 				},
 				`cannot register *github.com/dogmatiq/dogma_test.T: it is already registered as "2e4c3894-f76b-4ccb-a817-4422df36138e"`,
 				func() {
-					type T struct{ Timeout }
-					RegisterTimeout[*T]("2e4c3894-f76b-4ccb-a817-4422df36138e")
-					RegisterTimeout[*T]("3de60928-e9be-4a62-9fd8-60734f53cde5")
+					type T struct{ Deadline }
+					RegisterDeadline[*T]("2e4c3894-f76b-4ccb-a817-4422df36138e")
+					RegisterDeadline[*T]("3de60928-e9be-4a62-9fd8-60734f53cde5")
 				},
 			},
 			{
@@ -240,10 +240,10 @@ func TestMessageTypeRegistration(t *testing.T) {
 				},
 				`cannot register *github.com/dogmatiq/dogma_test.U: "66c69a42-ea81-4ca9-8587-bf88e8abaf34" is already associated with *github.com/dogmatiq/dogma_test.T`,
 				func() {
-					type T struct{ Timeout }
-					type U struct{ Timeout }
-					RegisterTimeout[*T]("66c69a42-ea81-4ca9-8587-bf88e8abaf34")
-					RegisterTimeout[*U]("66c69a42-ea81-4ca9-8587-bf88e8abaf34")
+					type T struct{ Deadline }
+					type U struct{ Deadline }
+					RegisterDeadline[*T]("66c69a42-ea81-4ca9-8587-bf88e8abaf34")
+					RegisterDeadline[*U]("66c69a42-ea81-4ca9-8587-bf88e8abaf34")
 				},
 			},
 			{
@@ -260,8 +260,8 @@ func TestMessageTypeRegistration(t *testing.T) {
 				},
 				`cannot register *github.com/dogmatiq/dogma_test.T: "<non-uuid>" is not a canonical RFC 9562 UUID: expected 36 characters`,
 				func() {
-					type T struct{ Timeout }
-					RegisterTimeout[*T]("<non-uuid>")
+					type T struct{ Deadline }
+					RegisterDeadline[*T]("<non-uuid>")
 				},
 			},
 		}
@@ -276,8 +276,8 @@ func TestMessageTypeRegistration(t *testing.T) {
 					expectPanic(t, c.EventError, c.EventFunc)
 				})
 
-				t.Run("timeout kind", func(t *testing.T) {
-					expectPanic(t, c.TimeoutError, c.TimeoutFunc)
+				t.Run("deadline kind", func(t *testing.T) {
+					expectPanic(t, c.DeadlineError, c.DeadlineFunc)
 				})
 			})
 		}

--- a/process.go
+++ b/process.go
@@ -10,7 +10,7 @@ import (
 // stateful decision-making that spans multiple [Command] messages.
 //
 // It handles [Event] messages and executes [Command] to enact further
-// application state changes. It may also schedule [Timeout] messages to perform
+// application state changes. It may also schedule [Deadline] messages to perform
 // actions at specific times. For example, to send a reminder if a customer
 // hasn't completed the checkout process within one hour.
 //
@@ -66,7 +66,7 @@ type ProcessMessageHandler[R ProcessRoot] interface {
 	// Events routed to the same instance operate on the same state. There's no
 	// need to create an instance in advance - it "exists" once the handler
 	// modifies its [ProcessRoot], executes a [Command], or schedules a
-	// [Timeout] against it.
+	// [Deadline] against it.
 	//
 	// The engine calls this method before handling the [Event]. The
 	// implementation may query external data - such as the application's
@@ -86,10 +86,10 @@ type ProcessMessageHandler[R ProcessRoot] interface {
 	// r is the [ProcessRoot] for the instance that the event targets, as
 	// determined by [ProcessMessageHandler].RouteEventToInstance. It reflects
 	// the state of the targeted instance after handling any prior [Event] or
-	// [Timeout] messages.
+	// [Deadline] messages.
 	//
 	// The implementation may change the instance's state, execute [Command]
-	// messages, schedule [Timeout] messages, or end the process. It may query
+	// messages, schedule [Deadline] messages, or end the process. It may query
 	// external data - such as the application's projections - but this isn't
 	// recommended. Wherever possible, logic should depend solely on information
 	// within r, s, and e.
@@ -97,7 +97,7 @@ type ProcessMessageHandler[R ProcessRoot] interface {
 	// The implementation must not modify r directly; use [ProcessScope].Mutate
 	// instead. The callback passed to Mutate must not use r or s.
 	//
-	// The engine atomically persists the state changes, events, and timeouts
+	// The engine atomically persists the state changes, events, and deadlines
 	// produced by exactly one successful invocation of this method for each
 	// event message. It doesn't guarantee the order, number, or concurrency of
 	// those attempts. Generally, the implementation doesn't need to perform any
@@ -117,14 +117,14 @@ type ProcessMessageHandler[R ProcessRoot] interface {
 		e Event,
 	) error
 
-	// HandleTimeout advances a process in response to a [Timeout] message.
+	// HandleDeadline advances a process in response to a [Deadline] message.
 	//
-	// r is the [ProcessRoot] for the instance that scheduled the timeout. It
+	// r is the [ProcessRoot] for the instance that scheduled the deadline. It
 	// reflects the state of the targeted instance after handling any prior
-	// [Event] or [Timeout] messages.
+	// [Event] or [Deadline] messages.
 	//
 	// The implementation may change the instance's state, execute [Command]
-	// messages, schedule [Timeout] messages, or end the process. It may query
+	// messages, schedule [Deadline] messages, or end the process. It may query
 	// external data - such as the application's projections - but this isn't
 	// recommended. Wherever possible, logic should depend solely on information
 	// within r, s, and t.
@@ -132,26 +132,27 @@ type ProcessMessageHandler[R ProcessRoot] interface {
 	// The implementation must not modify r directly; use [ProcessScope].Mutate
 	// instead. The callback passed to Mutate must not use r or s.
 	//
-	// The engine atomically persists the state changes, events, and timeouts
+	// The engine atomically persists the state changes, events, and deadlines
 	// produced by exactly one successful invocation of this method for each
-	// timeout message. It doesn't guarantee the order, number, or concurrency
+	// deadline message. It doesn't guarantee the order, number, or concurrency
 	// of those attempts. Generally, the implementation doesn't need to perform
 	// any synchronization or idempotency checks.
 	//
-	// The engine attempts to deliver timeout messages at their scheduled time.
+	// The engine attempts to deliver deadline messages at their scheduled time.
 	// It may deliver them later when recovering from downtime or retrying after
-	// a failure. It doesn't guarantee the relative delivery order of timeout
+	// a failure. It doesn't guarantee the relative delivery order of deadline
 	// messages with the same scheduled time.
 	//
-	// Not all processes use timeouts. Embed [NoTimeoutMessagesBehavior] in the
-	// handler implementation to indicate that timeout messages aren't used.
+	// Not all processes use deadlines. Embed [NoDeadlineMessagesBehavior] in
+	// the handler implementation to indicate that deadline messages aren't
+	// used.
 	//
 	// The handler may retain or mutate t and the values within it.
-	HandleTimeout(
+	HandleDeadline(
 		ctx context.Context,
 		r R,
-		s ProcessTimeoutScope[R],
-		t Timeout,
+		s ProcessDeadlineScope[R],
+		t Deadline,
 	) error
 }
 
@@ -159,7 +160,7 @@ type ProcessMessageHandler[R ProcessRoot] interface {
 // process instance used within [ProcessMessageHandler] implementations.
 //
 // It encapsulates process logic and provides a way to inspect the current state
-// when making decisions about which commands to execute and which timeouts to
+// when making decisions about which commands to execute and which deadlines to
 // schedule.
 type ProcessRoot interface {
 	// ProcessInstanceDescription returns a human-readable description of the
@@ -204,7 +205,7 @@ type ProcessConfigurer interface {
 	// Routes declares the message types that the handler consumes and produces.
 	//
 	// It accepts routes created by [HandlesEvent], [ExecutesCommand], and
-	// [SchedulesTimeout].
+	// [SchedulesDeadline].
 	Routes(...ProcessRoute)
 }
 
@@ -215,7 +216,7 @@ type ProcessConfigurer interface {
 // scope type that extends this interface:
 //
 //   - [ProcessEventScope]
-//   - [ProcessTimeoutScope]
+//   - [ProcessDeadlineScope]
 //
 // R is the application-defined [ProcessRoot] type for this handler.
 type ProcessScope[R ProcessRoot] interface {
@@ -227,8 +228,8 @@ type ProcessScope[R ProcessRoot] interface {
 	// When handling an [Event] message, it returns the ID produced by
 	// [ProcessMessageHandler].RouteEventToInstance during routing.
 	//
-	// When handling a [Timeout] message, it returns the ID of the instance that
-	// scheduled the timeout.
+	// When handling a [Deadline] message, it returns the ID of the instance
+	// that scheduled the deadline.
 	InstanceID() string
 
 	// Mutate changes the process instance's state by calling fn with the
@@ -251,13 +252,13 @@ type ProcessScope[R ProcessRoot] interface {
 
 	// End signals the end of a process.
 	//
-	// The engine discards the instance's state, cancels any pending [Timeout]
+	// The engine discards the instance's state, cancels any pending [Deadline]
 	// messages. It ignores any future messages that target the ended instance.
 	End()
 
 	// ExecuteCommand submits a [Command] for execution.
 	//
-	// The engine persists all commands and timeouts produced within this scope
+	// The engine persists all commands and deadlines produced within this scope
 	// in a single atomic operation after the [ProcessMessageHandler] finishes
 	// handling the inbound message. If the handler returns a non-nil error, the
 	// engine discards the messages.
@@ -265,16 +266,15 @@ type ProcessScope[R ProcessRoot] interface {
 	// This method panics if the process instance has ended.
 	ExecuteCommand(Command)
 
-	// ScheduleTimeout schedules a [Timeout] message to occur at the specified
-	// time.
+	// ScheduleDeadline schedules a [Deadline] message for the specified time.
 	//
-	// The engine persists all commands and timeouts produced within this scope
+	// The engine persists all commands and deadlines produced within this scope
 	// in a single atomic operation after the [ProcessMessageHandler] finishes
 	// handling the inbound message. If the handler returns a non-nil error, the
 	// engine discards the messages.
 	//
 	// This method panics if the process instance has ended.
-	ScheduleTimeout(Timeout, time.Time)
+	ScheduleDeadline(Deadline, time.Time)
 }
 
 // ProcessEventScope represents the context within which a
@@ -288,18 +288,19 @@ type ProcessEventScope[R ProcessRoot] interface {
 	RecordedAt() time.Time
 }
 
-// ProcessTimeoutScope represents the context within which a
-// [ProcessMessageHandler] handles a [Timeout] message.
+// ProcessDeadlineScope represents the context within which a
+// [ProcessMessageHandler] handles a [Deadline] message.
 //
 // R is the application-defined [ProcessRoot] type for this handler.
-type ProcessTimeoutScope[R ProcessRoot] interface {
+type ProcessDeadlineScope[R ProcessRoot] interface {
 	ProcessScope[R]
 
-	// ScheduledFor returns the time at which the timeout occurred.
+	// ScheduledFor returns the time at which the deadline message is to be
+	// delivered.
 	//
-	// Even though the engine attempts to deliver timeouts at their scheduled
-	// time, it may deliver them later when recovering from downtime or retrying
-	// after a failure.
+	// Even though the engine attempts to deliver deadline messages at their
+	// scheduled time, it may deliver them later when recovering from downtime
+	// or retrying after a failure.
 	ScheduledFor() time.Time
 }
 
@@ -310,22 +311,22 @@ type ProcessRoute interface {
 	isProcessRoute()
 }
 
-// NoTimeoutMessagesBehavior is an embeddable type for [ProcessMessageHandler]
-// implementations that don't use [Timeout] messages.
+// NoDeadlineMessagesBehavior is an embeddable type for [ProcessMessageHandler]
+// implementations that don't use [Deadline] messages.
 //
 // Embed this type in a [ProcessMessageHandler] to signal that the handler
-// doesn't schedule timeouts and to avoid boilerplate code that's never
+// doesn't schedule deadlines and to avoid boilerplate code that's never
 // used.
 //
 // R is the application-defined [ProcessRoot] type for this handler.
-type NoTimeoutMessagesBehavior[R ProcessRoot] struct{}
+type NoDeadlineMessagesBehavior[R ProcessRoot] struct{}
 
-// HandleTimeout panics with the [UnexpectedMessage] value.
-func (NoTimeoutMessagesBehavior[R]) HandleTimeout(
+// HandleDeadline panics with the [UnexpectedMessage] value.
+func (NoDeadlineMessagesBehavior[R]) HandleDeadline(
 	context.Context,
 	R,
-	ProcessTimeoutScope[R],
-	Timeout,
+	ProcessDeadlineScope[R],
+	Deadline,
 ) error {
 	panic(UnexpectedMessage)
 }
@@ -427,16 +428,16 @@ func (a *untypedProcessMessageHandler[R]) HandleEvent(
 	)
 }
 
-func (a *untypedProcessMessageHandler[R]) HandleTimeout(
+func (a *untypedProcessMessageHandler[R]) HandleDeadline(
 	ctx context.Context,
 	r ProcessRoot,
-	s ProcessTimeoutScope[ProcessRoot],
-	t Timeout,
+	s ProcessDeadlineScope[ProcessRoot],
+	t Deadline,
 ) error {
-	return a.handler.HandleTimeout(
+	return a.handler.HandleDeadline(
 		ctx,
 		r.(R),
-		untypedProcessTimeoutScope[R]{s},
+		untypedProcessDeadlineScope[R]{s},
 		t,
 	)
 }
@@ -457,14 +458,14 @@ func (a untypedProcessEventScope[R]) Mutate(fn func(R)) {
 	})
 }
 
-// untypedProcessTimeoutScope adapts a [ProcessTimeoutScope][ProcessRoot] to
-// [ProcessTimeoutScope][R] by narrowing the Mutate callback type.
-type untypedProcessTimeoutScope[R ProcessRoot] struct {
-	ProcessTimeoutScope[ProcessRoot]
+// untypedProcessDeadlineScope adapts a [ProcessDeadlineScope][ProcessRoot] to
+// [ProcessDeadlineScope][R] by narrowing the Mutate callback type.
+type untypedProcessDeadlineScope[R ProcessRoot] struct {
+	ProcessDeadlineScope[ProcessRoot]
 }
 
-func (a untypedProcessTimeoutScope[R]) Mutate(fn func(R)) {
-	a.ProcessTimeoutScope.Mutate(func(r ProcessRoot) {
+func (a untypedProcessDeadlineScope[R]) Mutate(fn func(R)) {
+	a.ProcessDeadlineScope.Mutate(func(r ProcessRoot) {
 		fn(r.(R))
 	})
 }

--- a/process.go
+++ b/process.go
@@ -147,12 +147,12 @@ type ProcessMessageHandler[R ProcessRoot] interface {
 	// the handler implementation to indicate that deadline messages aren't
 	// used.
 	//
-	// The handler may retain or mutate t and the values within it.
+	// The handler may retain or mutate d and the values within it.
 	HandleDeadline(
 		ctx context.Context,
 		r R,
 		s ProcessDeadlineScope[R],
-		t Deadline,
+		d Deadline,
 	) error
 }
 
@@ -432,13 +432,13 @@ func (a *untypedProcessMessageHandler[R]) HandleDeadline(
 	ctx context.Context,
 	r ProcessRoot,
 	s ProcessDeadlineScope[ProcessRoot],
-	t Deadline,
+	d Deadline,
 ) error {
 	return a.handler.HandleDeadline(
 		ctx,
 		r.(R),
 		untypedProcessDeadlineScope[R]{s},
-		t,
+		d,
 	)
 }
 

--- a/process.go
+++ b/process.go
@@ -127,7 +127,7 @@ type ProcessMessageHandler[R ProcessRoot] interface {
 	// messages, schedule [Deadline] messages, or end the process. It may query
 	// external data - such as the application's projections - but this isn't
 	// recommended. Wherever possible, logic should depend solely on information
-	// within r, s, and t.
+	// within r, s, and d.
 	//
 	// The implementation must not modify r directly; use [ProcessScope].Mutate
 	// instead. The callback passed to Mutate must not use r or s.

--- a/process_nocoverage.go
+++ b/process_nocoverage.go
@@ -1,5 +1,5 @@
 package dogma
 
-func (HandlesEventRoute) isProcessRoute()     {}
-func (ExecutesCommandRoute) isProcessRoute()  {}
-func (SchedulesTimeoutRoute) isProcessRoute() {}
+func (HandlesEventRoute) isProcessRoute()      {}
+func (ExecutesCommandRoute) isProcessRoute()   {}
+func (SchedulesDeadlineRoute) isProcessRoute() {}

--- a/process_test.go
+++ b/process_test.go
@@ -63,14 +63,14 @@ func TestStatelessProcess(t *testing.T) {
 	})
 }
 
-func TestNoTimeoutMessagesBehavior(t *testing.T) {
-	var v NoTimeoutMessagesBehavior[ProcessRoot]
+func TestNoDeadlineMessagesBehavior(t *testing.T) {
+	var v NoDeadlineMessagesBehavior[ProcessRoot]
 
 	expectPanic(
 		t,
 		UnexpectedMessage,
 		func() {
-			v.HandleTimeout(t.Context(), nil, nil, nil)
+			v.HandleDeadline(t.Context(), nil, nil, nil)
 		},
 	)
 }
@@ -185,25 +185,25 @@ func TestUntypedProcessMessageHandler(t *testing.T) {
 		})
 	})
 
-	t.Run("func HandleTimeout()", func(t *testing.T) {
+	t.Run("func HandleDeadline()", func(t *testing.T) {
 		t.Run("it narrows the root type and delegates to the wrapped handler", func(t *testing.T) {
-			err := adaptor.HandleTimeout(t.Context(), &processRootStub{}, nil, nil)
+			err := adaptor.HandleDeadline(t.Context(), &processRootStub{}, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !inner.handleTimeoutCalled {
-				t.Fatal("expected HandleTimeout to be called on the wrapped handler")
+			if !inner.handleDeadlineCalled {
+				t.Fatal("expected HandleDeadline to be called on the wrapped handler")
 			}
 		})
 
 		t.Run("it narrows the Mutate() callback type", func(t *testing.T) {
 			root := &processRootStub{}
-			scope := &processTimeoutScopeStub{root: root}
+			scope := &processDeadlineScopeStub{root: root}
 
 			h := &processHandlerStub{
 				routeID: "x",
 				routeOK: true,
-				handleTimeoutFunc: func(_ *processRootStub, s ProcessTimeoutScope[*processRootStub]) {
+				handleDeadlineFunc: func(_ *processRootStub, s ProcessDeadlineScope[*processRootStub]) {
 					s.Mutate(func(r *processRootStub) {
 						if r != root {
 							t.Fatalf("unexpected root: got %v, want %v", r, root)
@@ -214,7 +214,7 @@ func TestUntypedProcessMessageHandler(t *testing.T) {
 
 			expectType[ProcessHandlerRoute](t, ViaProcess(h)).
 				Handler().
-				HandleTimeout(t.Context(), root, scope, nil)
+				HandleDeadline(t.Context(), root, scope, nil)
 		})
 
 		t.Run("it panics if the root has an unexpected type", func(t *testing.T) {
@@ -223,7 +223,7 @@ func TestUntypedProcessMessageHandler(t *testing.T) {
 					t.Fatal("expected a panic")
 				}
 			}()
-			adaptor.HandleTimeout(t.Context(), nil, nil, nil)
+			adaptor.HandleDeadline(t.Context(), nil, nil, nil)
 		})
 	})
 }
@@ -235,13 +235,13 @@ func (*processRootStub) MarshalBinary() ([]byte, error)         { return nil, ni
 func (*processRootStub) UnmarshalBinary([]byte) error           { return nil }
 
 type processHandlerStub struct {
-	configured          bool
-	routeID             string
-	routeOK             bool
-	handleEventCalled   bool
-	handleTimeoutCalled bool
-	handleEventFunc     func(*processRootStub, ProcessEventScope[*processRootStub])
-	handleTimeoutFunc   func(*processRootStub, ProcessTimeoutScope[*processRootStub])
+	configured           bool
+	routeID              string
+	routeOK              bool
+	handleEventCalled    bool
+	handleDeadlineCalled bool
+	handleEventFunc      func(*processRootStub, ProcessEventScope[*processRootStub])
+	handleDeadlineFunc   func(*processRootStub, ProcessDeadlineScope[*processRootStub])
 }
 
 func (h *processHandlerStub) Configure(ProcessConfigurer) {
@@ -272,22 +272,22 @@ func (h *processHandlerStub) HandleEvent(
 	return nil
 }
 
-func (h *processHandlerStub) HandleTimeout(
+func (h *processHandlerStub) HandleDeadline(
 	_ context.Context,
 	r *processRootStub,
-	s ProcessTimeoutScope[*processRootStub],
-	_ Timeout,
+	s ProcessDeadlineScope[*processRootStub],
+	_ Deadline,
 ) error {
-	h.handleTimeoutCalled = true
-	if h.handleTimeoutFunc != nil {
-		h.handleTimeoutFunc(r, s)
+	h.handleDeadlineCalled = true
+	if h.handleDeadlineFunc != nil {
+		h.handleDeadlineFunc(r, s)
 	}
 	return nil
 }
 
 func init() {
 	assertIsComparable(StatelessProcessBehavior{})
-	assertIsComparable(NoTimeoutMessagesBehavior[ProcessRoot]{})
+	assertIsComparable(NoDeadlineMessagesBehavior[ProcessRoot]{})
 	assertIsComparable(StatelessProcessRoot{})
 }
 
@@ -298,9 +298,9 @@ type processEventScopeStub struct {
 
 func (s *processEventScopeStub) Mutate(fn func(ProcessRoot)) { fn(s.root) }
 
-type processTimeoutScopeStub struct {
-	ProcessTimeoutScope[ProcessRoot]
+type processDeadlineScopeStub struct {
+	ProcessDeadlineScope[ProcessRoot]
 	root ProcessRoot
 }
 
-func (s *processTimeoutScopeStub) Mutate(fn func(ProcessRoot)) { fn(s.root) }
+func (s *processDeadlineScopeStub) Mutate(fn func(ProcessRoot)) { fn(s.root) }


### PR DESCRIPTION
Rename all exported and unexported symbols, doc comments, tests, and documentation from "timeout" terminology to "deadline" terminology.

This is a purely mechanical rename with no semantic changes. The new terminology better aligns with Go conventions (`context.Deadline()`) and domain language — deadlines are reached at specific points in time, rather than "timing out".

## Changes

### Go API (all breaking)

| Old | New |
|-----|-----|
| `Timeout` | `Deadline` |
| `TimeoutValidationScope` | `DeadlineValidationScope` |
| `ProcessMessageHandler.HandleTimeout()` | `HandleDeadline()` |
| `ProcessTimeoutScope` | `ProcessDeadlineScope` |
| `ProcessScope.ScheduleTimeout()` | `ScheduleDeadline()` |
| `NoTimeoutMessagesBehavior` | `NoDeadlineMessagesBehavior` |
| `SchedulesTimeout()` | `SchedulesDeadline()` |
| `SchedulesTimeoutRoute` | `SchedulesDeadlineRoute` |
| `SchedulesTimeoutOption` | `SchedulesDeadlineOption` |
| `RegisterTimeout()` | `RegisterDeadline()` |
| `RegisterTimeoutOption` | `RegisterDeadlineOption` |

### Documentation

- Updated glossary: "Timeout" → "Deadline", "Process timeout scope" → "Process deadline scope"
- Updated `concepts.md` and `handler-type-comparison.md`
- Added CHANGELOG entry listing all renamed symbols

### ADR

- Added ADR-0035 documenting the rationale for the rename

Closes #212